### PR TITLE
add pybroker version info to __init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/_build/
 docs/notebooks/.ipynb_checkpoints
 dist/
 src/lib_pybroker.egg-info
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/notebooks/.ipynb_checkpoints
 dist/
 src/lib_pybroker.egg-info
 .idea/
+.pytest_cache/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lib-pybroker
-version = 1.1.7
+version = attr: pybroker.__version__
 url = http://www.pybroker.com
 author = Edward West
 author_email = edwest@pybroker.com

--- a/src/pybroker/__init__.py
+++ b/src/pybroker/__init__.py
@@ -46,3 +46,5 @@ from .scope import (
 )
 from .strategy import Strategy, TestResult
 from .vect import cross, highv, lowv, sumv
+
+__version__ = "1.1.7"


### PR DESCRIPTION
Thanks for your amazing work to PyBroker!
when I worked with PyBroker, just find that we can not get the version from PyBroker package! so I have add some functions to fix this problem.

1. add __version__ variable to __init__.py file to support print(pybroker.__version__)
2. fix setup.cfg file use attr to reference version info 