### PR TITLE
fix vec_cmma

### DIFF
--- a/docs/locales/zh_CN/LC_MESSAGES/notebooks/5. Writing Indicators.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/notebooks/5. Writing Indicators.po
@@ -215,10 +215,10 @@ msgstr ""
 #: Indicators.ipynb:427 Writing
 msgid ""
 "Finally, we can run the backtest with the following code. The ``warmup`` "
-"argument specifies that 20 bars need to pass before running the backtest "
+"argument specifies that 19 bars need to pass before running the backtest "
 "execution:"
 msgstr ""
-"最后，我们可以使用以下代码运行回测。``warmup`` 参数指定在运行回测执行之前需要经过 20 个 Bar："
+"最后，我们可以使用以下代码运行回测。``warmup`` 参数指定在运行回测执行之前需要经过 19 个 Bar："
 
 #: ../../source/notebooks/5. Indicators.ipynb:961 Writing
 #: df96659b29a541e183ec53a5adc58e5a

--- a/docs/source/notebooks/5. Writing Indicators.ipynb
+++ b/docs/source/notebooks/5. Writing Indicators.ipynb
@@ -16,8 +16,8 @@
    "id": "9693079f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.438006Z",
-     "start_time": "2023-08-26T09:47:11.372011500Z"
+     "end_time": "2023-08-26T10:34:51.806308Z",
+     "start_time": "2023-08-26T10:34:51.549595Z"
     }
    },
    "outputs": [],
@@ -40,8 +40,8 @@
    "id": "e2f2cbb5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.439007400Z",
-     "start_time": "2023-08-26T09:47:11.378573200Z"
+     "end_time": "2023-08-26T10:34:51.813415700Z",
+     "start_time": "2023-08-26T10:34:51.809307600Z"
     }
    },
    "outputs": [],
@@ -87,8 +87,8 @@
    "id": "d82ef9b8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.458007200Z",
-     "start_time": "2023-08-26T09:47:11.382089900Z"
+     "end_time": "2023-08-26T10:34:52.447704100Z",
+     "start_time": "2023-08-26T10:34:51.812416700Z"
     }
    },
    "outputs": [],
@@ -114,8 +114,8 @@
    "id": "5133a343",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.508007Z",
-     "start_time": "2023-08-26T09:47:11.387080200Z"
+     "end_time": "2023-08-26T10:34:52.480284500Z",
+     "start_time": "2023-08-26T10:34:52.448705Z"
     }
    },
    "outputs": [
@@ -143,8 +143,8 @@
    "id": "72058bc2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.547579800Z",
-     "start_time": "2023-08-26T09:47:11.396010400Z"
+     "end_time": "2023-08-26T10:34:52.920125500Z",
+     "start_time": "2023-08-26T10:34:52.475308300Z"
     }
    },
    "outputs": [
@@ -190,8 +190,8 @@
    "id": "df73939a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.690545100Z",
-     "start_time": "2023-08-26T09:47:11.538579400Z"
+     "end_time": "2023-08-26T10:34:53.063724600Z",
+     "start_time": "2023-08-26T10:34:52.920125500Z"
     }
    },
    "outputs": [
@@ -224,8 +224,8 @@
    "id": "482ba588",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.829740100Z",
-     "start_time": "2023-08-26T09:47:11.690545100Z"
+     "end_time": "2023-08-26T10:34:54.053170900Z",
+     "start_time": "2023-08-26T10:34:53.070723400Z"
     }
    },
    "outputs": [
@@ -260,8 +260,8 @@
    "id": "ad7b58ff",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.835425700Z",
-     "start_time": "2023-08-26T09:47:11.830737900Z"
+     "end_time": "2023-08-26T10:34:54.053170900Z",
+     "start_time": "2023-08-26T10:34:54.050375300Z"
     }
    },
    "outputs": [],
@@ -291,8 +291,8 @@
    "id": "1af703ce",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.849148600Z",
-     "start_time": "2023-08-26T09:47:11.835425700Z"
+     "end_time": "2023-08-26T10:34:54.070896100Z",
+     "start_time": "2023-08-26T10:34:54.055170500Z"
     }
    },
    "outputs": [],
@@ -317,15 +317,15 @@
    "id": "e623ab3a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:11.902435500Z",
-     "start_time": "2023-08-26T09:47:11.851146700Z"
+     "end_time": "2023-08-26T10:34:54.118951200Z",
+     "start_time": "2023-08-26T10:34:54.071894800Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<diskcache.core.Cache at 0x134ef608d50>"
+       "<diskcache.core.Cache at 0x14aff6dcb90>"
       ]
      },
      "execution_count": 10,
@@ -342,7 +342,7 @@
    "id": "4fde3541",
    "metadata": {},
    "source": [
-    "Finally, we can run the backtest with the following code. The ``warmup`` argument specifies that 20 bars need to pass before running the backtest execution:"
+    "Finally, we can run the backtest with the following code. The ``warmup`` argument specifies that 19 bars need to pass before running the backtest execution:"
    ]
   },
   {
@@ -351,8 +351,8 @@
    "id": "c38b4612",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:12.012127300Z",
-     "start_time": "2023-08-26T09:47:11.860387600Z"
+     "end_time": "2023-08-26T10:34:55.936368300Z",
+     "start_time": "2023-08-26T10:34:54.082952200Z"
     }
    },
    "outputs": [
@@ -423,32 +423,32 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>end_market_value</td>\n",
-       "      <td>113219.0200</td>\n",
+       "      <td>109644.5100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>total_pnl</td>\n",
-       "      <td>13219.0200</td>\n",
+       "      <td>9644.5100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>unrealized_pnl</td>\n",
-       "      <td>0.0000</td>\n",
+       "      <td>-0.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>total_return_pct</td>\n",
-       "      <td>13.2190</td>\n",
+       "      <td>9.6445</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>total_profit</td>\n",
-       "      <td>52193.0100</td>\n",
+       "      <td>48992.6100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>total_loss</td>\n",
-       "      <td>-38973.9900</td>\n",
+       "      <td>-39348.1000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -458,42 +458,42 @@
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>max_drawdown</td>\n",
-       "      <td>-14411.9800</td>\n",
+       "      <td>-13956.4800</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>max_drawdown_pct</td>\n",
-       "      <td>-13.0302</td>\n",
+       "      <td>-13.0293</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>win_rate</td>\n",
-       "      <td>56.6667</td>\n",
+       "      <td>55.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
        "      <td>loss_rate</td>\n",
-       "      <td>43.3333</td>\n",
+       "      <td>45.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
        "      <td>winning_trades</td>\n",
-       "      <td>34.0000</td>\n",
+       "      <td>33.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>losing_trades</td>\n",
-       "      <td>26.0000</td>\n",
+       "      <td>27.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
        "      <td>avg_pnl</td>\n",
-       "      <td>220.3170</td>\n",
+       "      <td>160.7418</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
        "      <td>avg_return_pct</td>\n",
-       "      <td>0.2243</td>\n",
+       "      <td>0.1717</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
@@ -503,12 +503,12 @@
        "    <tr>\n",
        "      <th>18</th>\n",
        "      <td>avg_profit</td>\n",
-       "      <td>1535.0885</td>\n",
+       "      <td>1484.6245</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
        "      <td>avg_profit_pct</td>\n",
-       "      <td>1.4915</td>\n",
+       "      <td>1.4864</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>20</th>\n",
@@ -518,12 +518,12 @@
        "    <tr>\n",
        "      <th>21</th>\n",
        "      <td>avg_loss</td>\n",
-       "      <td>-1498.9996</td>\n",
+       "      <td>-1457.3370</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>22</th>\n",
        "      <td>avg_loss_pct</td>\n",
-       "      <td>-1.4327</td>\n",
+       "      <td>-1.4352</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
@@ -533,7 +533,7 @@
        "    <tr>\n",
        "      <th>24</th>\n",
        "      <td>largest_win</td>\n",
-       "      <td>4179.6000</td>\n",
+       "      <td>4050.6000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25</th>\n",
@@ -548,7 +548,7 @@
        "    <tr>\n",
        "      <th>27</th>\n",
        "      <td>largest_loss</td>\n",
-       "      <td>-4717.4400</td>\n",
+       "      <td>-4569.6000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>28</th>\n",
@@ -573,37 +573,37 @@
        "    <tr>\n",
        "      <th>32</th>\n",
        "      <td>sharpe</td>\n",
-       "      <td>0.0368</td>\n",
+       "      <td>0.0273</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>33</th>\n",
        "      <td>sortino</td>\n",
-       "      <td>0.0343</td>\n",
+       "      <td>0.0248</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>34</th>\n",
        "      <td>profit_factor</td>\n",
-       "      <td>1.1665</td>\n",
+       "      <td>1.1225</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>35</th>\n",
        "      <td>ulcer_index</td>\n",
-       "      <td>1.5832</td>\n",
+       "      <td>1.6694</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>36</th>\n",
        "      <td>upi</td>\n",
-       "      <td>0.0170</td>\n",
+       "      <td>0.0124</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>37</th>\n",
        "      <td>equity_r2</td>\n",
-       "      <td>0.0044</td>\n",
+       "      <td>0.0236</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>38</th>\n",
        "      <td>std_error</td>\n",
-       "      <td>4207.9120</td>\n",
+       "      <td>3976.4859</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -613,43 +613,43 @@
        "                      name        value\n",
        "0              trade_count      60.0000\n",
        "1     initial_market_value  100000.0000\n",
-       "2         end_market_value  113219.0200\n",
-       "3                total_pnl   13219.0200\n",
-       "4           unrealized_pnl       0.0000\n",
-       "5         total_return_pct      13.2190\n",
-       "6             total_profit   52193.0100\n",
-       "7               total_loss  -38973.9900\n",
+       "2         end_market_value  109644.5100\n",
+       "3                total_pnl    9644.5100\n",
+       "4           unrealized_pnl      -0.0000\n",
+       "5         total_return_pct       9.6445\n",
+       "6             total_profit   48992.6100\n",
+       "7               total_loss  -39348.1000\n",
        "8               total_fees       0.0000\n",
-       "9             max_drawdown  -14411.9800\n",
-       "10        max_drawdown_pct     -13.0302\n",
-       "11                win_rate      56.6667\n",
-       "12               loss_rate      43.3333\n",
-       "13          winning_trades      34.0000\n",
-       "14           losing_trades      26.0000\n",
-       "15                 avg_pnl     220.3170\n",
-       "16          avg_return_pct       0.2243\n",
+       "9             max_drawdown  -13956.4800\n",
+       "10        max_drawdown_pct     -13.0293\n",
+       "11                win_rate      55.0000\n",
+       "12               loss_rate      45.0000\n",
+       "13          winning_trades      33.0000\n",
+       "14           losing_trades      27.0000\n",
+       "15                 avg_pnl     160.7418\n",
+       "16          avg_return_pct       0.1717\n",
        "17          avg_trade_bars       3.0000\n",
-       "18              avg_profit    1535.0885\n",
-       "19          avg_profit_pct       1.4915\n",
+       "18              avg_profit    1484.6245\n",
+       "19          avg_profit_pct       1.4864\n",
        "20  avg_winning_trade_bars       3.0000\n",
-       "21                avg_loss   -1498.9996\n",
-       "22            avg_loss_pct      -1.4327\n",
+       "21                avg_loss   -1457.3370\n",
+       "22            avg_loss_pct      -1.4352\n",
        "23   avg_losing_trade_bars       3.0000\n",
-       "24             largest_win    4179.6000\n",
+       "24             largest_win    4050.6000\n",
        "25         largest_win_pct       4.1000\n",
        "26        largest_win_bars       3.0000\n",
-       "27            largest_loss   -4717.4400\n",
+       "27            largest_loss   -4569.6000\n",
        "28        largest_loss_pct      -4.4000\n",
        "29       largest_loss_bars       3.0000\n",
        "30                max_wins       7.0000\n",
        "31              max_losses       4.0000\n",
-       "32                  sharpe       0.0368\n",
-       "33                 sortino       0.0343\n",
-       "34           profit_factor       1.1665\n",
-       "35             ulcer_index       1.5832\n",
-       "36                     upi       0.0170\n",
-       "37               equity_r2       0.0044\n",
-       "38               std_error    4207.9120"
+       "32                  sharpe       0.0273\n",
+       "33                 sortino       0.0248\n",
+       "34           profit_factor       1.1225\n",
+       "35             ulcer_index       1.6694\n",
+       "36                     upi       0.0124\n",
+       "37               equity_r2       0.0236\n",
+       "38               std_error    3976.4859"
       ]
      },
      "execution_count": 11,
@@ -658,7 +658,7 @@
     }
    ],
    "source": [
-    "result = strategy.backtest(warmup=20)\n",
+    "result = strategy.backtest(warmup=19)\n",
     "result.metrics_df.round(4)"
    ]
   },
@@ -688,8 +688,8 @@
    "id": "3ca7b8ff",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:12.013127900Z",
-     "start_time": "2023-08-26T09:47:11.951901300Z"
+     "end_time": "2023-08-26T10:34:56.146983600Z",
+     "start_time": "2023-08-26T10:34:55.934367200Z"
     }
    },
    "outputs": [
@@ -741,8 +741,8 @@
    "id": "ac38a028",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:12.014126700Z",
-     "start_time": "2023-08-26T09:47:11.959619200Z"
+     "end_time": "2023-08-26T10:34:56.148993300Z",
+     "start_time": "2023-08-26T10:34:56.143083300Z"
     }
    },
    "outputs": [
@@ -791,8 +791,8 @@
    "id": "14641672",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:13.656771600Z",
-     "start_time": "2023-08-26T09:47:11.977132Z"
+     "end_time": "2023-08-26T10:34:58.447592200Z",
+     "start_time": "2023-08-26T10:34:56.150994200Z"
     }
    },
    "outputs": [
@@ -973,8 +973,8 @@
    "id": "b3cc6d4b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-08-26T09:47:13.674341400Z",
-     "start_time": "2023-08-26T09:47:13.655772800Z"
+     "end_time": "2023-08-26T10:34:58.466685500Z",
+     "start_time": "2023-08-26T10:34:58.447592200Z"
     }
    },
    "outputs": [

--- a/docs/source/notebooks/5. Writing Indicators.ipynb
+++ b/docs/source/notebooks/5. Writing Indicators.ipynb
@@ -14,7 +14,12 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "9693079f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.438006Z",
+     "start_time": "2023-08-26T09:47:11.372011500Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -33,7 +38,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "e2f2cbb5",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.439007400Z",
+     "start_time": "2023-08-26T09:47:11.378573200Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def cmma(bar_data, lookback):\n",
@@ -45,14 +55,14 @@
     "        out = np.array([np.nan for _ in range(n)])\n",
     "        \n",
     "        # For all bars starting at lookback:\n",
-    "        for i in range(lookback, n):\n",
+    "        for i in range(lookback, n+1):\n",
     "            # Calculate the moving average for the lookback.\n",
     "            ma = 0\n",
     "            for j in range(i - lookback, i):\n",
     "                ma += values[j]\n",
     "            ma /= lookback\n",
     "            # Subtract the moving average from value.\n",
-    "            out[i] = values[i] - ma\n",
+    "            out[i-1] = values[i-1] - ma\n",
     "        return out\n",
     "    \n",
     "    # Calculate with close prices.\n",
@@ -75,7 +85,12 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "d82ef9b8",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.458007200Z",
+     "start_time": "2023-08-26T09:47:11.382089900Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pybroker\n",
@@ -97,15 +112,18 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "5133a343",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.508007Z",
+     "start_time": "2023-08-26T09:47:11.387080200Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading bar data...\n",
-      "[*********************100%***********************]  1 of 1 completed\n",
-      "Loaded bar data: 0:00:01 \n",
+      "Loaded cached bar data.\n",
       "\n"
      ]
     }
@@ -123,7 +141,12 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "72058bc2",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.547579800Z",
+     "start_time": "2023-08-26T09:47:11.396010400Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -134,11 +157,11 @@
        "2020-04-06         NaN\n",
        "2020-04-07         NaN\n",
        "                ...   \n",
-       "2022-03-25    1.967502\n",
-       "2022-03-28    3.288005\n",
-       "2022-03-29    4.968507\n",
-       "2022-03-30    3.790999\n",
-       "2022-03-31    2.171002\n",
+       "2022-03-25    2.238002\n",
+       "2022-03-28    3.388505\n",
+       "2022-03-29    4.861006\n",
+       "2022-03-30    3.760999\n",
+       "2022-03-31    2.249002\n",
        "Length: 505, dtype: float64"
       ]
      },
@@ -165,12 +188,17 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "df73939a",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.690545100Z",
+     "start_time": "2023-08-26T09:47:11.538579400Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "4.655495452880842"
+       "4.298749542236337"
       ]
      },
      "execution_count": 6,
@@ -194,12 +222,17 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "482ba588",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.829740100Z",
+     "start_time": "2023-08-26T09:47:11.690545100Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.7495800114455111"
+       "0.7361480400880157"
       ]
      },
      "execution_count": 7,
@@ -225,7 +258,12 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "ad7b58ff",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.835425700Z",
+     "start_time": "2023-08-26T09:47:11.830737900Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def buy_cmma_cross(ctx):\n",
@@ -251,7 +289,12 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "1af703ce",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.849148600Z",
+     "start_time": "2023-08-26T09:47:11.835425700Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from pybroker import Strategy\n",
@@ -272,12 +315,17 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "e623ab3a",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:11.902435500Z",
+     "start_time": "2023-08-26T09:47:11.851146700Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<diskcache.core.Cache at 0x7f45b0a73bb0>"
+       "<diskcache.core.Cache at 0x134ef608d50>"
       ]
      },
      "execution_count": 10,
@@ -301,7 +349,12 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "c38b4612",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:12.012127300Z",
+     "start_time": "2023-08-26T09:47:11.860387600Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -311,20 +364,7 @@
       "\n",
       "Loaded cached bar data.\n",
       "\n",
-      "Computing indicators...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100% (1 of 1) |##########################| Elapsed Time: 0:00:00 Time:  0:00:00\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Loaded cached indicator data.\n",
       "\n",
       "Test split: 2020-04-01 00:00:00 to 2022-03-31 00:00:00\n"
      ]
@@ -341,7 +381,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Finished backtest: 0:00:01\n"
+      "Finished backtest: 0:00:02\n"
      ]
     },
     {
@@ -383,12 +423,12 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>end_market_value</td>\n",
-       "      <td>100759.3600</td>\n",
+       "      <td>113219.0200</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>total_pnl</td>\n",
-       "      <td>759.3600</td>\n",
+       "      <td>13219.0200</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -398,17 +438,17 @@
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>total_return_pct</td>\n",
-       "      <td>0.7594</td>\n",
+       "      <td>13.2190</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>total_profit</td>\n",
-       "      <td>41596.7500</td>\n",
+       "      <td>52193.0100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>total_loss</td>\n",
-       "      <td>-40837.3900</td>\n",
+       "      <td>-38973.9900</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -418,42 +458,42 @@
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>max_drawdown</td>\n",
-       "      <td>-13446.9300</td>\n",
+       "      <td>-14411.9800</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>max_drawdown_pct</td>\n",
-       "      <td>-11.9774</td>\n",
+       "      <td>-13.0302</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>win_rate</td>\n",
-       "      <td>53.3333</td>\n",
+       "      <td>56.6667</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
        "      <td>loss_rate</td>\n",
-       "      <td>46.6667</td>\n",
+       "      <td>43.3333</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
        "      <td>winning_trades</td>\n",
-       "      <td>32.0000</td>\n",
+       "      <td>34.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>losing_trades</td>\n",
-       "      <td>28.0000</td>\n",
+       "      <td>26.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
        "      <td>avg_pnl</td>\n",
-       "      <td>12.6560</td>\n",
+       "      <td>220.3170</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
        "      <td>avg_return_pct</td>\n",
-       "      <td>0.0293</td>\n",
+       "      <td>0.2243</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
@@ -463,12 +503,12 @@
        "    <tr>\n",
        "      <th>18</th>\n",
        "      <td>avg_profit</td>\n",
-       "      <td>1299.8984</td>\n",
+       "      <td>1535.0885</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
        "      <td>avg_profit_pct</td>\n",
-       "      <td>1.2609</td>\n",
+       "      <td>1.4915</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>20</th>\n",
@@ -478,12 +518,12 @@
        "    <tr>\n",
        "      <th>21</th>\n",
        "      <td>avg_loss</td>\n",
-       "      <td>-1458.4782</td>\n",
+       "      <td>-1498.9996</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>22</th>\n",
        "      <td>avg_loss_pct</td>\n",
-       "      <td>-1.3782</td>\n",
+       "      <td>-1.4327</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
@@ -493,7 +533,7 @@
        "    <tr>\n",
        "      <th>24</th>\n",
        "      <td>largest_win</td>\n",
-       "      <td>4263.4500</td>\n",
+       "      <td>4179.6000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25</th>\n",
@@ -508,12 +548,12 @@
        "    <tr>\n",
        "      <th>27</th>\n",
        "      <td>largest_loss</td>\n",
-       "      <td>-4675.6700</td>\n",
+       "      <td>-4717.4400</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>28</th>\n",
        "      <td>largest_loss_pct</td>\n",
-       "      <td>-4.1700</td>\n",
+       "      <td>-4.4000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>29</th>\n",
@@ -533,32 +573,37 @@
        "    <tr>\n",
        "      <th>32</th>\n",
        "      <td>sharpe</td>\n",
-       "      <td>0.0023</td>\n",
+       "      <td>0.0368</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>33</th>\n",
-       "      <td>profit_factor</td>\n",
-       "      <td>1.0092</td>\n",
+       "      <td>sortino</td>\n",
+       "      <td>0.0343</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>34</th>\n",
-       "      <td>ulcer_index</td>\n",
-       "      <td>1.8823</td>\n",
+       "      <td>profit_factor</td>\n",
+       "      <td>1.1665</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>35</th>\n",
-       "      <td>upi</td>\n",
-       "      <td>0.0019</td>\n",
+       "      <td>ulcer_index</td>\n",
+       "      <td>1.5832</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>36</th>\n",
-       "      <td>equity_r2</td>\n",
-       "      <td>0.0015</td>\n",
+       "      <td>upi</td>\n",
+       "      <td>0.0170</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>37</th>\n",
+       "      <td>equity_r2</td>\n",
+       "      <td>0.0044</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
        "      <td>std_error</td>\n",
-       "      <td>3385.1968</td>\n",
+       "      <td>4207.9120</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -568,42 +613,43 @@
        "                      name        value\n",
        "0              trade_count      60.0000\n",
        "1     initial_market_value  100000.0000\n",
-       "2         end_market_value  100759.3600\n",
-       "3                total_pnl     759.3600\n",
+       "2         end_market_value  113219.0200\n",
+       "3                total_pnl   13219.0200\n",
        "4           unrealized_pnl       0.0000\n",
-       "5         total_return_pct       0.7594\n",
-       "6             total_profit   41596.7500\n",
-       "7               total_loss  -40837.3900\n",
+       "5         total_return_pct      13.2190\n",
+       "6             total_profit   52193.0100\n",
+       "7               total_loss  -38973.9900\n",
        "8               total_fees       0.0000\n",
-       "9             max_drawdown  -13446.9300\n",
-       "10        max_drawdown_pct     -11.9774\n",
-       "11                win_rate      53.3333\n",
-       "12               loss_rate      46.6667\n",
-       "13          winning_trades      32.0000\n",
-       "14           losing_trades      28.0000\n",
-       "15                 avg_pnl      12.6560\n",
-       "16          avg_return_pct       0.0293\n",
+       "9             max_drawdown  -14411.9800\n",
+       "10        max_drawdown_pct     -13.0302\n",
+       "11                win_rate      56.6667\n",
+       "12               loss_rate      43.3333\n",
+       "13          winning_trades      34.0000\n",
+       "14           losing_trades      26.0000\n",
+       "15                 avg_pnl     220.3170\n",
+       "16          avg_return_pct       0.2243\n",
        "17          avg_trade_bars       3.0000\n",
-       "18              avg_profit    1299.8984\n",
-       "19          avg_profit_pct       1.2609\n",
+       "18              avg_profit    1535.0885\n",
+       "19          avg_profit_pct       1.4915\n",
        "20  avg_winning_trade_bars       3.0000\n",
-       "21                avg_loss   -1458.4782\n",
-       "22            avg_loss_pct      -1.3782\n",
+       "21                avg_loss   -1498.9996\n",
+       "22            avg_loss_pct      -1.4327\n",
        "23   avg_losing_trade_bars       3.0000\n",
-       "24             largest_win    4263.4500\n",
+       "24             largest_win    4179.6000\n",
        "25         largest_win_pct       4.1000\n",
        "26        largest_win_bars       3.0000\n",
-       "27            largest_loss   -4675.6700\n",
-       "28        largest_loss_pct      -4.1700\n",
+       "27            largest_loss   -4717.4400\n",
+       "28        largest_loss_pct      -4.4000\n",
        "29       largest_loss_bars       3.0000\n",
        "30                max_wins       7.0000\n",
        "31              max_losses       4.0000\n",
-       "32                  sharpe       0.0023\n",
-       "33           profit_factor       1.0092\n",
-       "34             ulcer_index       1.8823\n",
-       "35                     upi       0.0019\n",
-       "36               equity_r2       0.0015\n",
-       "37               std_error    3385.1968"
+       "32                  sharpe       0.0368\n",
+       "33                 sortino       0.0343\n",
+       "34           profit_factor       1.1665\n",
+       "35             ulcer_index       1.5832\n",
+       "36                     upi       0.0170\n",
+       "37               equity_r2       0.0044\n",
+       "38               std_error    4207.9120"
       ]
      },
      "execution_count": 11,
@@ -640,7 +686,12 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "3ca7b8ff",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:12.013127900Z",
+     "start_time": "2023-08-26T09:47:11.951901300Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -688,7 +739,12 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "ac38a028",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:12.014126700Z",
+     "start_time": "2023-08-26T09:47:11.959619200Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -733,7 +789,12 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "14641672",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:13.656771600Z",
+     "start_time": "2023-08-26T09:47:11.977132Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -746,7 +807,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100% (2 of 2) |##########################| Elapsed Time: 0:00:01 Time:  0:00:01\n"
+      "100% (2 of 2) |##########################| Elapsed Time: 0:00:02 Time:  0:00:02\n"
      ]
     },
     {
@@ -830,35 +891,35 @@
        "      <th>500</th>\n",
        "      <td>PG</td>\n",
        "      <td>2022-03-25</td>\n",
-       "      <td>1.967502</td>\n",
+       "      <td>2.238002</td>\n",
        "      <td>153.919998</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>501</th>\n",
        "      <td>PG</td>\n",
        "      <td>2022-03-28</td>\n",
-       "      <td>3.288005</td>\n",
+       "      <td>3.388505</td>\n",
        "      <td>153.919998</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>502</th>\n",
        "      <td>PG</td>\n",
        "      <td>2022-03-29</td>\n",
-       "      <td>4.968507</td>\n",
+       "      <td>4.861006</td>\n",
        "      <td>156.470001</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>503</th>\n",
        "      <td>PG</td>\n",
        "      <td>2022-03-30</td>\n",
-       "      <td>3.790999</td>\n",
+       "      <td>3.760999</td>\n",
        "      <td>156.470001</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>504</th>\n",
        "      <td>PG</td>\n",
        "      <td>2022-03-31</td>\n",
-       "      <td>2.171002</td>\n",
+       "      <td>2.249002</td>\n",
        "      <td>156.470001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -874,11 +935,11 @@
        "3       PG 2020-04-06       NaN         NaN\n",
        "4       PG 2020-04-07       NaN  120.059998\n",
        "..     ...        ...       ...         ...\n",
-       "500     PG 2022-03-25  1.967502  153.919998\n",
-       "501     PG 2022-03-28  3.288005  153.919998\n",
-       "502     PG 2022-03-29  4.968507  156.470001\n",
-       "503     PG 2022-03-30  3.790999  156.470001\n",
-       "504     PG 2022-03-31  2.171002  156.470001\n",
+       "500     PG 2022-03-25  2.238002  153.919998\n",
+       "501     PG 2022-03-28  3.388505  153.919998\n",
+       "502     PG 2022-03-29  4.861006  156.470001\n",
+       "503     PG 2022-03-30  3.760999  156.470001\n",
+       "504     PG 2022-03-31  2.249002  156.470001\n",
        "\n",
        "[505 rows x 4 columns]"
       ]
@@ -910,7 +971,12 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "b3cc6d4b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-26T09:47:13.674341400Z",
+     "start_time": "2023-08-26T09:47:13.655772800Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -966,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi, Ed, I have fixed the calculate of cmma like this: 
def cmma(bar_data, lookback):

    @njit  # Enable Numba JIT.
    def vec_cmma(values):
        # Initialize the result array.
        n = len(values)
        out = np.array([np.nan for _ in range(n)])
        
        # For all bars starting at lookback:
        for i in range(lookback, **n+1**):
            # Calculate the moving average for the lookback.
            ma = 0
            for j in range(i - lookback, i):
                ma += values[j]
            ma /= lookback
            # Subtract the moving average from value.
            out[**i-1**] = values[**i-1**] - ma
        return out
    
    # Calculate with close prices.
    return vec_cmma(bar_data.close)