### PR TITLE
Fix: repalce logging.warn with logging.warning

### DIFF
--- a/src/pybroker/log.py
+++ b/src/pybroker/log.py
@@ -454,7 +454,7 @@ class Logger:
     def _warn(self, msg: str, *args):
         if self._disabled:
             return
-        logging.warn(msg, *args)
+        logging.warning(msg, *args)
 
     def _format_order(
         self,


### PR DESCRIPTION
1. logging.warn is deprecated