### PR TITLE
Feat log

### DIFF
--- a/src/pybroker/__init__.py
+++ b/src/pybroker/__init__.py
@@ -38,6 +38,8 @@ from pybroker.portfolio import Entry, Order, Position, Trade
 from pybroker.scope import (
     disable_logging,
     enable_logging,
+    disable_progress_bar,
+    enable_progress_bar,
     param,
     register_columns,
     unregister_columns,

--- a/src/pybroker/data.py
+++ b/src/pybroker/data.py
@@ -503,7 +503,8 @@ class YFinance(DataSource):
         _adjust: Optional[str],
     ) -> pd.DataFrame:
         """:meta private:"""
-        df = yfinance.download(list(symbols), start=start_date, end=end_date)
+        yf_progress_bar_flag = (self._logger.disable_flag and self._logger.progress_bar_flag)
+        df = yfinance.download(list(symbols), start=start_date, end=end_date, progress=yf_progress_bar_flag)
         if df.columns.empty:
             return pd.DataFrame(
                 columns=[

--- a/src/pybroker/log.py
+++ b/src/pybroker/log.py
@@ -57,6 +57,16 @@ class Logger:
             self._progress_bar = None
             self._out("")
 
+    @property
+    def progress_bar_flag(self):
+        """Disables Progress Bar flag"""
+        return not self._progress_bar_disabled
+
+    @property
+    def disable_flag(self):
+        """Disables logging flag"""
+        return not self._disabled
+
     def disable(self):
         """Disables logging."""
         self._disabled = True


### PR DESCRIPTION
1. when we use pb.disable_logging() in pybroker, the yfinance will still show progress bar
2. we add progress_bar_flag and disable_flag func to log.py to return a flag to yfinance in data.py
3. we add progress parameter to yfinance to show or hidden progress bar in data.py