### PR TITLE
Fix: replace == with is

### DIFF
--- a/src/pybroker/scope.py
+++ b/src/pybroker/scope.py
@@ -171,7 +171,7 @@ class StaticScope:
         self, name: str, value: Optional[Any] = _EMPTY_PARAM
     ) -> Optional[Any]:
         """Get or set a global parameter."""
-        if value == _EMPTY_PARAM:
+        if value is _EMPTY_PARAM:
             return self._params.get(name, None)
         self._params[name] = value
         return value


### PR DESCRIPTION
Hi, Ed, when we want to use global `pybroker.param` to set variable, but, when the variable is a pandas.DataFrame, it will fail!
1. I fix this issue using `is` to replace `==`
2. then, we can set any type here.

```python
import pandas as pd

import pybroker as pb

df = pd.DataFrame([1, 2, 4])

pb.param(name="name", value=df)
pb.param("name")
```
it will work now!