### PR TITLE
try fix sharpe_ratio calculation

### DIFF
--- a/src/pybroker/eval.py
+++ b/src/pybroker/eval.py
@@ -950,7 +950,7 @@ class EvaluateMixin:
         return returns.dropna()
 
     def _calc_bar_changes(self, df: pd.DataFrame) -> NDArray[np.float64]:
-        changes = df["market_value"] - df["market_value"].shift(1)
+        changes = (df["market_value"] - df["market_value"].shift(1))/df["market_value"].shift(1)
         return changes.dropna().to_numpy()
 
     def _calc_eval_metrics(


### PR DESCRIPTION
I think in my understanding the sharpe ratio calculation requires the bar changes in rate, not the diff of market value.

I could be wrong, but I think the `_calc_bar_changes` should be updated like below since it is only used for sharpe ratio calculation anyway. 