### PR TITLE
Fix typing for backtest method train_size parameter

### DIFF
--- a/src/pybroker/strategy.py
+++ b/src/pybroker/strategy.py
@@ -1030,7 +1030,7 @@ class Strategy(
         between_time: Optional[tuple[str, str]] = None,
         days: Optional[Union[str, Day, Iterable[Union[str, Day]]]] = None,
         lookahead: int = 1,
-        train_size: int = 0,
+        train_size: float = 0,
         shuffle: bool = False,
         calc_bootstrap: bool = False,
         disable_parallel: bool = False,


### PR DESCRIPTION
Found it when running a linter on some code calling this method. Based on the docs this should not be an int but a float.