### PR TITLE
ci: add Python 3.14 to Package matrix (experimental)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,18 +56,22 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python:
           - version: "3.12"
             toxenv: "py312"
           - version: "3.11"
             toxenv: "py311"
+          - version: "3.14"
+            toxenv: "py314"
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.version }}
+          allow-prereleases: true
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ namespace_packages = True
 check_untyped_defs = True
 
 [tox:tox]
-envlist = py39,py310,py311,py312
+envlist = py39,py310,py311,py312,py314
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
## Summary

Adds **Python 3.14** to the `Package` workflow's test matrix and to the tox `envlist`. One version only — a companion PR adds 3.13.

- `.github/workflows/main.yml` — new matrix entry `{ version: "3.14", toxenv: "py314" }`; `fail-fast: false`; `allow-prereleases: true` on `setup-python` so the runner picks up the latest 3.14.x.
- `setup.cfg` — `envlist = py39,py310,py311,py312,py314`.

No changes to `install_requires`, `src/`, or tests.

## Findings — is pybroker compatible with Python 3.14?

**Yes — perhaps surprisingly.** Verified green on my fork's CI ([run 24582828793](https://github.com/Pirat83/pybroker/actions/runs/24582828793), branch `feature/py313-py314`):

| Job | Result |
|---|---|
| Test (3.11, py311) | ✅ |
| Test (3.12, py312) | ✅ |
| Test (3.13, py313) | ✅ |
| Test (3.14, py314) | ✅ |

All 4074 tests pass on 3.14. My initial branch marked 3.14 as `experimental: true` / `continue-on-error: true` as a safety net (Python 3.14 released Oct 2025; numba wheel support for new Python versions typically lags). It turned out not to be needed — nothing broke.

### Library compatibility on 3.14

Every runtime dep declared in `setup.cfg` installed cleanly via pip on Ubuntu:

| Package | Floor in setup.cfg | 3.14 status | Notes |
|---|---|---|---|
| `numpy` | `>=1.26.4,<3` | ✅ wheels | |
| `pandas` | `>=2.2.0,<4` | ✅ wheels | |
| `numba` | `>=0.64.0,<1` | ✅ wheels | 3.14 wheels published |
| `diskcache` | `>=5.4.0,<6` | ✅ pure-Python | |
| `joblib` | `>=1.2.0,<2` | ✅ pure-Python | |
| `progressbar2` | `>=4.1.1,<5` | ✅ pure-Python | |
| `akshare` | `>=1.10.1,<2` | ✅ wheels | |
| `alpaca-py` | `>=0.7.2,<1` | ✅ wheels | |
| `yahooquery` | `>=2.3.7,<3` | ✅ wheels | |
| `yfinance` | `>=0.2.55,<2` | ✅ wheels | |

No dep-floor bumps needed. No test-suite breakage. No removed / deprecated API usage in `pybroker` itself tripped 3.14 changes.

## Maintainer decision (cross-ref #224 question 1A)

This PR corresponds to one option of the Python-matrix checkbox in #224:

- [ ] **Option 1A.a** — Keep 3.11 + 3.12 only → **close this PR**
- [ ] **Option 1A.b** — Add 3.13 only → **close this PR; merge the 3.13 PR**
- [x] **Option 1A.c** — Add 3.13 + 3.14 → **merge this PR AND the 3.13 PR**

If you want to track the broader design thread, see [#224 comment](https://github.com/edtechre/pybroker/pull/224#issuecomment-4269985937).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
