### PR TITLE
ci(asv-pr): bump action versions to silence Node 20 deprecation

### DIFF
--- a/.github/actions/setup-pybroker/action.yml
+++ b/.github/actions/setup-pybroker/action.yml
@@ -10,13 +10,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('setup.cfg', 'requirements.txt') }}

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: asv continuous
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
         # and this step would fail with "Resource not accessible by integration".
         # Benchmarks still run and results are in the job summary either way.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: asv-continuous
           path: sticky-comment.md


### PR DESCRIPTION
## Summary

Per maintainer ask on #224 housekeeping: bump the GitHub Actions
versions that GitHub flagged with Node 20 deprecation warnings on
#224's CI run.

Scoped to the asv-pr path only (`asv-pr.yml` + `setup-pybroker`
composite) to keep the diff minimal; `main.yml` / `schedule.yml`
deliberately out of scope for a future housekeeping pass.

- `actions/setup-python`                        v5 → v6
- `actions/cache`                               v4 → v5
- `actions/checkout`                            v4 → v6
- `marocchino/sticky-pull-request-comment`      v2 → v3

No behavior change.

## Test plan

- [ ] asv-pr workflow still green on fork (zero-diff scenario)
- [ ] No Node 20 deprecation warning on the workflow run