### PR TITLE
ci: add nightly asv matrix workflow (Python 3.11/3.12/3.13)

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -1,0 +1,54 @@
+name: ASV Benchmarks (Nightly)
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: asv-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: asv run (Python ${{ matrix.python.version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - version: "3.11"
+          - version: "3.12"
+          - version: "3.13"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-pybroker
+        with:
+          python-version: ${{ matrix.python.version }}
+
+      - name: Configure asv machine identity
+        env:
+          PY_VERSION: ${{ matrix.python.version }}
+        run: asv machine --yes --machine "ci-ubuntu-latest-py${PY_VERSION}"
+
+      - name: Run asv against master HEAD
+        env:
+          PY_VERSION: ${{ matrix.python.version }}
+        run: |
+          asv run HEAD^! \
+            --machine "ci-ubuntu-latest-py${PY_VERSION}" \
+            --show-stderr
+
+      - name: Upload asv results
+        uses: actions/upload-artifact@v4
+        with:
+          name: asv-results-py${{ matrix.python.version }}-${{ github.run_id }}
+          path: .asv/results/
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds the nightly full-Python-matrix asv run the maintainer picked in
#224 question 1B: *"Single Python in the PR gate; add a separate
nightly/weekly workflow covering the full version matrix."*

- Triggers: `schedule` at 05:00 UTC daily (well before the existing
  `schedule.yml` cron at 12:00 UTC to avoid runner contention) plus
  `workflow_dispatch` for manual runs.
- Matrix: 3.11, 3.12, 3.13 — mirrors `main.yml`'s `Package` test
  matrix. Kept in sync so perf tracking covers every version we claim
  to support.
- `fail-fast: false` so one Python version failing doesn't cancel the
  others.
- Reuses `./.github/actions/setup-pybroker` with the `python-version`
  input (the composite already accepts it).
- Per-Python asv `machine` identity (`ci-ubuntu-latest-pyX.Y`) so
  results don't collide if someone later merges artifacts into a
  single asv store.
- `asv run HEAD^!` benchmarks the current master commit per run.
  Results upload as an `asv-results-pyX.Y-<run_id>` artifact with 30
  day retention.
- No sticky comment, no blocking semantics — this is trend
  collection; `asv-pr.yml` remains the gate.

Action pins intentionally match the current dev-branch convention
(`actions/checkout@v4`, `actions/upload-artifact@v4`) so this diff
doesn't mix "new workflow" with "version bumps". Housekeeping bumps
for the asv-pr path live in #234.

## Test plan

- [ ] `workflow_dispatch` on fork → three parallel jobs, one per
      Python version, each finishing with an `asv-results-pyX.Y-<run_id>`
      artifact containing `.asv/results/`.
- [ ] Second consecutive run uploads a fresh artifact (each run
      benchmarks the tip independently).