### PR TITLE
Add optional Adanos sentiment data adapter

### DIFF
--- a/docs/source/adanos_sentiment.rst
+++ b/docs/source/adanos_sentiment.rst
@@ -1,0 +1,41 @@
+Adanos Sentiment Features
+=========================
+
+PyBroker can use custom data columns as execution context fields and model
+features. ``AdanosSentiment`` wraps any existing ``DataSource`` and adds
+optional stock sentiment features from the Adanos Market Sentiment API.
+
+The wrapped data source still provides the required OHLCV bars:
+
+.. code-block:: python
+
+   import os
+
+   from pybroker import Strategy, YFinance
+   from pybroker.ext.data import AdanosSentiment
+
+   data_source = AdanosSentiment(
+      YFinance(),
+      api_key=os.environ["ADANOS_API_KEY"],
+      sources=("reddit", "x", "news", "polymarket"),
+   )
+
+   def exec_fn(ctx):
+      if not ctx.long_pos() and ctx.adanos_sentiment[-1] > 0.25:
+         ctx.buy_shares = 100
+         ctx.hold_bars = 5
+
+   strategy = Strategy(data_source, "1/1/2024", "1/1/2025")
+   strategy.add_execution(exec_fn, ["AAPL", "MSFT", "NVDA"])
+   result = strategy.backtest()
+
+The adapter registers these aggregate columns by default:
+
+* ``adanos_sentiment``
+* ``adanos_buzz``
+* ``adanos_mentions``
+
+It also registers per-source columns such as ``adanos_reddit_sentiment``,
+``adanos_x_buzz``, ``adanos_news_mentions``, and
+``adanos_polymarket_sentiment``. These columns are available in model
+``train_data`` and ``test_data`` just like price columns or indicators.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -159,6 +159,7 @@ To learn how to use PyBroker, see the notebooks under the *User Guide*:
    notebooks/5. Writing Indicators
    notebooks/6. Training a Model
    notebooks/7. Creating a Custom Data Source
+   Adanos Sentiment Features <adanos_sentiment>
    notebooks/8. Applying Stops
    notebooks/9. Rebalancing Positions
    notebooks/10. Rotational Trading

--- a/src/pybroker/ext/data.py
+++ b/src/pybroker/ext/data.py
@@ -7,14 +7,93 @@ This code is licensed under Apache 2.0 with Commons Clause license
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Iterable, Mapping, Optional, Union
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 import akshare
+import numpy as np
 import pandas as pd
 from yahooquery import Ticker
 
 from pybroker.common import DataCol, to_datetime
 from pybroker.data import DataSource
+
+_ADANOS_DEFAULT_BASE_URL = "https://api.adanos.org"
+_ADANOS_SOURCE_PATHS = {
+    "reddit": "/reddit/stocks/v1",
+    "x": "/x/stocks/v1",
+    "news": "/news/stocks/v1",
+    "polymarket": "/polymarket/stocks/v1",
+}
+_ADANOS_METRICS = ("sentiment", "buzz", "mentions")
+
+
+def _clean_adanos_source(source: str) -> str:
+    source = source.lower().strip()
+    if source not in _ADANOS_SOURCE_PATHS:
+        raise ValueError(
+            f"Unsupported Adanos source: {source!r}.\n"
+            f"Supported sources: {list(_ADANOS_SOURCE_PATHS.keys())}."
+        )
+    return source
+
+
+def _empty_adanos_features(
+    columns: Iterable[str],
+) -> dict[str, np.float64]:
+    return {col: np.float64(np.nan) for col in columns}
+
+
+def _metric_value(data: Mapping[str, Any], metric: str) -> Optional[float]:
+    keys = {
+        "sentiment": ("sentiment_score", "sentiment"),
+        "buzz": ("buzz_score", "buzz"),
+        "mentions": ("mentions", "trade_count"),
+    }[metric]
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            return float(value)
+    return None
+
+
+def _adanos_columns(
+    sources: Iterable[str], include_aggregate: bool
+) -> tuple[str, ...]:
+    columns = []
+    if include_aggregate:
+        columns.extend(f"adanos_{metric}" for metric in _ADANOS_METRICS)
+    for source in sources:
+        columns.extend(
+            f"adanos_{source}_{metric}" for metric in _ADANOS_METRICS
+        )
+    return tuple(columns)
+
+
+def _fetch_adanos_json(
+    source: str,
+    symbol: str,
+    days: int,
+    *,
+    api_key: str,
+    base_url: str,
+    timeout: float,
+) -> Mapping[str, Any]:
+    path = _ADANOS_SOURCE_PATHS[source]
+    query = urlencode({"days": days})
+    url = f"{base_url.rstrip('/')}{path}/stock/{symbol}?{query}"
+    request = Request(url, headers={"X-API-Key": api_key})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            import json
+
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        if exc.code == 404:
+            return {}
+        raise
 
 
 class AKShare(DataSource):
@@ -169,3 +248,236 @@ class YQuery(DataSource):
             ]
         ]
         return df
+
+
+class AdanosSentiment(DataSource):
+    r"""Enriches another :class:`pybroker.data.DataSource` with Adanos Market
+    Sentiment API features.
+
+    The wrapped data source still provides the required OHLCV bars. Adanos
+    sentiment is left-joined onto those bars as custom PyBroker columns, making
+    the features available from :class:`pybroker.context.ExecContext` and model
+    training data.
+
+    Args:
+        data_source: Data source used to query price bars.
+        api_key: Adanos API key.
+        sources: Adanos sources to query. Supported values are ``"reddit"``,
+            ``"x"``, ``"news"``, and ``"polymarket"``.
+        include_aggregate: Whether to include aggregate ``adanos_sentiment``,
+            ``adanos_buzz``, and ``adanos_mentions`` columns across sources.
+        base_url: Adanos API base URL.
+        timeout: HTTP timeout in seconds.
+    """
+
+    _CACHE_KEY = "adanos_sentiment"
+
+    def __init__(
+        self,
+        data_source: DataSource,
+        api_key: str,
+        sources: Iterable[str] = ("reddit", "x", "news", "polymarket"),
+        include_aggregate: bool = True,
+        base_url: str = _ADANOS_DEFAULT_BASE_URL,
+        timeout: float = 10.0,
+    ):
+        super().__init__()
+        self.data_source = data_source
+        self.api_key = api_key
+        self.sources = tuple(
+            _clean_adanos_source(source) for source in sources
+        )
+        if not self.sources:
+            raise ValueError("At least one Adanos source is required.")
+        self.include_aggregate = include_aggregate
+        self.base_url = base_url
+        self.timeout = timeout
+        self.columns = _adanos_columns(self.sources, include_aggregate)
+        self._scope.register_custom_cols(self.columns)
+
+    def query(
+        self,
+        symbols: Union[str, Iterable[str]],
+        start_date: Union[str, datetime],
+        end_date: Union[str, datetime],
+        timeframe: Optional[str] = "",
+        adjust: Optional[Any] = None,
+    ) -> pd.DataFrame:
+        cache_adjust = (
+            self._CACHE_KEY,
+            adjust,
+            self.sources,
+            self.include_aggregate,
+            self.base_url,
+        )
+        return super().query(
+            symbols, start_date, end_date, timeframe, cache_adjust
+        )
+
+    def _fetch_data(
+        self,
+        symbols: frozenset[str],
+        start_date: datetime,
+        end_date: datetime,
+        timeframe: Optional[str],
+        adjust: Optional[Any],
+    ) -> pd.DataFrame:
+        """:meta private:"""
+        data_source_adjust = (
+            adjust[1]
+            if isinstance(adjust, tuple) and adjust[0] == self._CACHE_KEY
+            else adjust
+        )
+        price_df = self.data_source.query(
+            symbols, start_date, end_date, timeframe, data_source_adjust
+        )
+        if price_df.empty:
+            for col in self.columns:
+                price_df[col] = np.nan
+            return price_df
+
+        features = self._fetch_sentiment_features(
+            symbols, start_date, end_date
+        )
+        if features.empty:
+            for col in self.columns:
+                price_df[col] = np.nan
+            return price_df
+
+        price_df = price_df.copy()
+        price_df[DataCol.DATE.value] = pd.to_datetime(
+            price_df[DataCol.DATE.value]
+        )
+        price_df["_adanos_date"] = price_df[DataCol.DATE.value].dt.date
+        features = features.copy()
+        features["_adanos_date"] = pd.to_datetime(
+            features[DataCol.DATE.value]
+        ).dt.date
+        enriched = price_df.merge(
+            features,
+            how="left",
+            left_on=[DataCol.SYMBOL.value, "_adanos_date"],
+            right_on=[DataCol.SYMBOL.value, "_adanos_date"],
+            suffixes=("", "_adanos_feature"),
+        )
+        enriched.drop(
+            columns=["_adanos_date", f"{DataCol.DATE.value}_adanos_feature"],
+            inplace=True,
+        )
+        for col in self.columns:
+            if col not in enriched.columns:
+                enriched[col] = np.nan
+        return enriched
+
+    def _fetch_sentiment_features(
+        self,
+        symbols: frozenset[str],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> pd.DataFrame:
+        rows = []
+        days = max(1, (end_date.date() - start_date.date()).days + 1)
+        for symbol in symbols:
+            daily_rows: dict[pd.Timestamp, dict[str, Any]] = {}
+            for source in self.sources:
+                payload = self._get_sentiment_payload(source, symbol, days)
+                self._add_source_payload(daily_rows, source, end_date, payload)
+            for date, values in daily_rows.items():
+                values[DataCol.SYMBOL.value] = symbol
+                values[DataCol.DATE.value] = date
+                self._set_aggregate_values(values)
+                rows.append(values)
+        if not rows:
+            return pd.DataFrame(
+                columns=(
+                    DataCol.SYMBOL.value,
+                    DataCol.DATE.value,
+                    *self.columns,
+                )
+            )
+        features = pd.DataFrame(rows)
+        for col in self.columns:
+            if col not in features.columns:
+                features[col] = np.nan
+        return features[
+            [DataCol.SYMBOL.value, DataCol.DATE.value, *self.columns]
+        ]
+
+    def _get_sentiment_payload(
+        self,
+        source: str,
+        symbol: str,
+        days: int,
+    ) -> Mapping[str, Any]:
+        return _fetch_adanos_json(
+            source,
+            symbol,
+            days,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            timeout=self.timeout,
+        )
+
+    def _add_source_payload(
+        self,
+        daily_rows: dict[pd.Timestamp, dict[str, Any]],
+        source: str,
+        end_date: datetime,
+        payload: Mapping[str, Any],
+    ):
+        trend = (
+            payload.get("daily_trend") or payload.get("trend_history") or []
+        )
+        added_daily_trend = False
+        if isinstance(trend, list):
+            for item in trend:
+                if not isinstance(item, Mapping):
+                    continue
+                date = item.get("date")
+                if date is None:
+                    continue
+                self._set_source_values(
+                    daily_rows,
+                    pd.to_datetime(date).normalize(),
+                    source,
+                    item,
+                )
+                added_daily_trend = True
+        if payload and not added_daily_trend:
+            self._set_source_values(
+                daily_rows,
+                pd.Timestamp(end_date).normalize(),
+                source,
+                payload,
+            )
+
+    def _set_source_values(
+        self,
+        daily_rows: dict[pd.Timestamp, dict[str, Any]],
+        date: pd.Timestamp,
+        source: str,
+        data: Mapping[str, Any],
+    ):
+        row = daily_rows.setdefault(date, _empty_adanos_features(self.columns))
+        for metric in _ADANOS_METRICS:
+            value = _metric_value(data, metric)
+            if value is not None:
+                row[f"adanos_{source}_{metric}"] = value
+
+    def _set_aggregate_values(self, values: dict[str, Any]):
+        if not self.include_aggregate:
+            return
+        for metric in _ADANOS_METRICS:
+            source_values = [
+                values.get(f"adanos_{source}_{metric}")
+                for source in self.sources
+                if not pd.isna(values.get(f"adanos_{source}_{metric}"))
+            ]
+            if not source_values:
+                continue
+            if metric == "mentions":
+                values[f"adanos_{metric}"] = float(sum(source_values))
+            else:
+                values[f"adanos_{metric}"] = float(
+                    sum(source_values) / len(source_values)
+                )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ This code is licensed under Apache 2.0 with Commons Clause license
 """
 
 import akshare
+import json
 import os
 import pandas as pd
 import pytest
@@ -14,16 +15,20 @@ import re
 import yfinance
 from .fixtures import *  # noqa: F401
 from datetime import datetime
+from urllib.error import HTTPError
 from pybroker.cache import DataSourceCacheKey
 from pybroker.common import to_seconds
 from pybroker.data import (
     Alpaca,
     AlpacaCrypto,
+    DataSource,
     DataSourceCacheMixin,
     YFinance,
 )
 from pybroker.ext.data import AKShare
+from pybroker.ext.data import AdanosSentiment
 from pybroker.ext.data import YQuery
+from pybroker.ext import data as ext_data
 from unittest import mock
 from yahooquery import Ticker
 
@@ -45,6 +50,30 @@ ALPACA_COLS = [
     "vwap",
 ]
 ALPACA_CRYPTO_COLS = ALPACA_COLS + ["trade_count"]
+
+
+class StaticDataSource(DataSource):
+    def __init__(self, df):
+        super().__init__()
+        self.df = df
+
+    def _fetch_data(self, symbols, start_date, end_date, _timeframe, _adjust):
+        df = self.df[self.df["symbol"].isin(symbols)].copy()
+        return df[(df["date"] >= start_date) & (df["date"] <= end_date)]
+
+
+class JsonResponse:
+    def __init__(self, data):
+        self.data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return json.dumps(self.data).encode("utf-8")
 
 
 @pytest.fixture()
@@ -777,3 +806,313 @@ class TestYQuery:
                 Ticker, "history", return_value=expected_df
             ):
                 yq.query(symbols, START_DATE, END_DATE, "90m")
+
+
+class TestAdanosSentiment:
+    @pytest.mark.usefixtures("scope", "setup_ds_cache")
+    def test_query_enriches_wrapped_data_source(self):
+        prices = pd.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 2),
+                    datetime(2024, 1, 3),
+                    datetime(2024, 1, 2),
+                    datetime(2024, 1, 3),
+                ],
+                "symbol": ["AAPL", "AAPL", "MSFT", "MSFT"],
+                "open": [1, 2, 3, 4],
+                "high": [2, 3, 4, 5],
+                "low": [0, 1, 2, 3],
+                "close": [1.5, 2.5, 3.5, 4.5],
+                "volume": [10, 20, 30, 40],
+            }
+        )
+
+        def fetcher(source, symbol, days, **_kwargs):
+            assert source in {"reddit", "news"}
+            assert days == 2
+            sentiment = 0.2 if symbol == "AAPL" else -0.1
+            if source == "news":
+                sentiment += 0.2
+            return {
+                "sentiment_score": 0.99,
+                "buzz_score": 99,
+                "mentions": 99,
+                "daily_trend": [
+                    {
+                        "date": "2024-01-02",
+                        "sentiment_score": sentiment,
+                        "buzz_score": 10,
+                        "mentions": 2,
+                    },
+                    {
+                        "date": "2024-01-03",
+                        "sentiment_score": sentiment + 0.1,
+                        "buzz_score": 12,
+                        "mentions": 3,
+                    },
+                ],
+            }
+
+        with mock.patch.object(ext_data, "_fetch_adanos_json", fetcher):
+            adanos = AdanosSentiment(
+                StaticDataSource(prices),
+                api_key="test-key",
+                sources=("reddit", "news"),
+            )
+            df = adanos.query(["AAPL", "MSFT"], "2024-01-02", "2024-01-03")
+
+        assert {
+            "adanos_sentiment",
+            "adanos_buzz",
+            "adanos_mentions",
+            "adanos_reddit_sentiment",
+            "adanos_reddit_buzz",
+            "adanos_reddit_mentions",
+            "adanos_news_sentiment",
+            "adanos_news_buzz",
+            "adanos_news_mentions",
+        }.issubset(df.columns)
+        aapl = df[
+            (df["symbol"] == "AAPL")
+            & (df["date"] == pd.Timestamp("2024-01-02"))
+        ].iloc[0]
+        assert aapl["adanos_reddit_sentiment"] == pytest.approx(0.2)
+        assert aapl["adanos_news_sentiment"] == pytest.approx(0.4)
+        assert aapl["adanos_sentiment"] == pytest.approx(0.3)
+        assert aapl["adanos_buzz"] == pytest.approx(10)
+        assert aapl["adanos_mentions"] == pytest.approx(4)
+        aapl_end = df[
+            (df["symbol"] == "AAPL")
+            & (df["date"] == pd.Timestamp("2024-01-03"))
+        ].iloc[0]
+        assert aapl_end["adanos_reddit_sentiment"] == pytest.approx(0.3)
+        assert aapl_end["adanos_news_sentiment"] == pytest.approx(0.5)
+        assert aapl_end["adanos_sentiment"] == pytest.approx(0.4)
+        assert aapl_end["adanos_buzz"] == pytest.approx(12)
+        assert aapl_end["adanos_mentions"] == pytest.approx(6)
+
+    @pytest.mark.usefixtures("scope")
+    def test_query_joins_timezone_aware_dates(self):
+        prices = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-02", tz="US/Eastern")],
+                "symbol": ["AAPL"],
+                "open": [1],
+                "high": [2],
+                "low": [0],
+                "close": [1.5],
+                "volume": [10],
+            }
+        )
+
+        def fetcher(_source, _symbol, _days, **_kwargs):
+            return {
+                "daily_trend": [
+                    {
+                        "date": "2024-01-02",
+                        "sentiment_score": 0.25,
+                        "buzz_score": 11,
+                        "mentions": 2,
+                    }
+                ]
+            }
+
+        with mock.patch.object(ext_data, "_fetch_adanos_json", fetcher):
+            adanos = AdanosSentiment(
+                StaticDataSource(prices),
+                api_key="test-key",
+                sources=("reddit",),
+            )
+            df = adanos.query(
+                "AAPL",
+                "2024-01-02T00:00:00-05:00",
+                "2024-01-02T00:00:00-05:00",
+            )
+
+        assert df["adanos_reddit_sentiment"].iloc[0] == pytest.approx(0.25)
+
+    @pytest.mark.usefixtures("scope")
+    def test_query_uses_top_level_payload_without_daily_trend(self):
+        prices = pd.DataFrame(
+            {
+                "date": [datetime(2024, 1, 3)],
+                "symbol": ["AAPL"],
+                "open": [1],
+                "high": [2],
+                "low": [0],
+                "close": [1.5],
+                "volume": [10],
+            }
+        )
+
+        def fetcher(_source, _symbol, _days, **_kwargs):
+            return {
+                "sentiment_score": 0.45,
+                "buzz_score": 22,
+                "mentions": 7,
+            }
+
+        with mock.patch.object(ext_data, "_fetch_adanos_json", fetcher):
+            adanos = AdanosSentiment(
+                StaticDataSource(prices),
+                api_key="test-key",
+                sources=("reddit",),
+            )
+            df = adanos.query("AAPL", "2024-01-03", "2024-01-03")
+
+        assert df["adanos_reddit_sentiment"].iloc[0] == pytest.approx(0.45)
+        assert df["adanos_reddit_buzz"].iloc[0] == pytest.approx(22)
+        assert df["adanos_reddit_mentions"].iloc[0] == pytest.approx(7)
+
+    @pytest.mark.usefixtures("scope")
+    def test_query_when_aggregate_disabled(self):
+        prices = pd.DataFrame(
+            {
+                "date": [datetime(2024, 1, 2)],
+                "symbol": ["AAPL"],
+                "open": [1],
+                "high": [2],
+                "low": [0],
+                "close": [1.5],
+                "volume": [10],
+            }
+        )
+
+        def fetcher(_source, _symbol, _days, **_kwargs):
+            return {
+                "daily_trend": [
+                    {
+                        "date": "2024-01-02",
+                        "sentiment_score": 0.25,
+                        "buzz_score": 11,
+                        "mentions": 2,
+                    }
+                ]
+            }
+
+        with mock.patch.object(ext_data, "_fetch_adanos_json", fetcher):
+            adanos = AdanosSentiment(
+                StaticDataSource(prices),
+                api_key="test-key",
+                sources=("reddit",),
+                include_aggregate=False,
+            )
+            df = adanos.query("AAPL", "2024-01-02", "2024-01-02")
+
+        assert "adanos_sentiment" not in df.columns
+        assert df["adanos_reddit_sentiment"].iloc[0] == pytest.approx(0.25)
+
+    @pytest.mark.usefixtures("scope")
+    def test_query_when_source_has_no_data(self):
+        prices = pd.DataFrame(
+            {
+                "date": [datetime(2024, 1, 2)],
+                "symbol": ["AAPL"],
+                "open": [1],
+                "high": [2],
+                "low": [0],
+                "close": [1.5],
+                "volume": [10],
+            }
+        )
+        with mock.patch.object(
+            ext_data, "_fetch_adanos_json", lambda *_a, **_k: {}
+        ):
+            adanos = AdanosSentiment(
+                StaticDataSource(prices),
+                api_key="test-key",
+                sources=("reddit",),
+            )
+            df = adanos.query("AAPL", "2024-01-02", "2024-01-02")
+
+        assert pd.isna(df["adanos_sentiment"].iloc[0])
+        assert pd.isna(df["adanos_reddit_sentiment"].iloc[0])
+
+    @pytest.mark.usefixtures("scope", "setup_enabled_ds_cache")
+    def test_query_uses_separate_cache_key_from_wrapped_source(self):
+        prices = pd.DataFrame(
+            {
+                "date": [datetime(2024, 1, 2)],
+                "symbol": ["AAPL"],
+                "open": [1],
+                "high": [2],
+                "low": [0],
+                "close": [1.5],
+                "volume": [10],
+            }
+        )
+        data_source = StaticDataSource(prices)
+        data_source.query("AAPL", "2024-01-02", "2024-01-02")
+
+        def fetcher(_source, _symbol, _days, **_kwargs):
+            return {
+                "daily_trend": [
+                    {
+                        "date": "2024-01-02",
+                        "sentiment_score": 0.4,
+                        "buzz_score": 20,
+                        "mentions": 5,
+                    }
+                ]
+            }
+
+        with mock.patch.object(ext_data, "_fetch_adanos_json", fetcher):
+            adanos = AdanosSentiment(
+                data_source,
+                api_key="test-key",
+                sources=("reddit",),
+            )
+            df = adanos.query("AAPL", "2024-01-02", "2024-01-02")
+
+        assert df["adanos_reddit_sentiment"].iloc[0] == pytest.approx(0.4)
+
+    @pytest.mark.usefixtures("scope")
+    def test_init_when_unsupported_source_then_error(self):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Unsupported Adanos source: 'crypto'."),
+        ):
+            AdanosSentiment(
+                StaticDataSource(pd.DataFrame()),
+                api_key="test-key",
+                sources=("crypto",),
+            )
+
+    def test_fetch_adanos_json_uses_source_endpoint_and_api_key(self):
+        def urlopen(request, timeout):
+            assert timeout == 3
+            assert request.full_url == (
+                "https://example.com/reddit/stocks/v1/stock/AAPL?days=7"
+            )
+            assert request.get_header("X-api-key") == "test-key"
+            return JsonResponse({"sentiment_score": 0.5})
+
+        with mock.patch.object(ext_data, "urlopen", urlopen):
+            payload = ext_data._fetch_adanos_json(
+                "reddit",
+                "AAPL",
+                7,
+                api_key="test-key",
+                base_url="https://example.com/",
+                timeout=3,
+            )
+
+        assert payload == {"sentiment_score": 0.5}
+
+    def test_fetch_adanos_json_when_404_returns_empty_payload(self):
+        def urlopen(_request, timeout):
+            assert timeout == 3
+            raise HTTPError("url", 404, "Not Found", {}, None)
+
+        with mock.patch.object(ext_data, "urlopen", urlopen):
+            payload = ext_data._fetch_adanos_json(
+                "reddit",
+                "MISSING",
+                7,
+                api_key="test-key",
+                base_url="https://example.com",
+                timeout=3,
+            )
+
+        assert payload == {}


### PR DESCRIPTION
## Summary

- adds an optional `AdanosSentiment` data-source wrapper in `pybroker.ext.data`
- enriches any existing PyBroker `DataSource` with Adanos sentiment custom columns for ML features and execution rules
- documents the adapter and covers enrichment, missing-data behavior, source validation, cache-key isolation, timezone-aware date joins, daily-vs-period payload handling, aggregate opt-out, and HTTP client behavior with tests

## Why

PyBroker already supports custom data columns and ML walkforward workflows. This adapter keeps OHLCV data ownership with the user's existing data source, while adding optional alternative-data features such as `adanos_sentiment`, `adanos_buzz`, and per-source Reddit/X/news/Polymarket columns.

The implementation does not add a required dependency and does not change existing behavior unless users opt into the wrapper.

## Tests

- `.venv/bin/python -m ruff check src/pybroker/ext/data.py tests/test_data.py`
- `.venv/bin/python -m ruff format --check src/pybroker/ext/data.py tests/test_data.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_data.py -q` — 96 passed
- `.venv/bin/python -m pytest tests/ -q` — 4077 passed