### PR TITLE
fix: typecheck broken by mypy 2.0 ndarray narrowing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ exclude =
     tests*
 
 [mypy]
-python_version = 3.9
+python_version = 3.11
 warn_unused_configs = True
 show_error_context = True
 pretty = True

--- a/src/pybroker/common.py
+++ b/src/pybroker/common.py
@@ -24,6 +24,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    cast,
 )
 
 _tf_pattern: Final = re.compile(r"(\d+)([A-Za-z]+)")
@@ -415,5 +416,4 @@ def get_unique_sorted_dates(col: pd.Series) -> Sequence[np.datetime64]:
     # TODO: Remove after Pandas 1.0 is no longer supported.
     if hasattr(result, "to_numpy"):
         result = result.to_numpy(copy=True)
-    result = np.sort(result)
-    return result
+    return cast(Sequence[np.datetime64], np.sort(result))


### PR DESCRIPTION
## Summary

The daily `Schedule` workflow on `master` started failing on 2026-05-07 in
the `Type check` job, with no code change since 2026-04-19. Affected runs:
[edtechre/pybroker run 25495780223](https://github.com/edtechre/pybroker/actions/runs/25495780223),
[Pirat83/pybroker run 25498436143](https://github.com/Pirat83/pybroker/actions/runs/25498436143).

**Root cause:** `tox.ini`'s `[testenv:typecheck]` declares `mypy` unpinned,
and today's resolver picked **mypy 2.0.0**, which tightened `np.ndarray`
generic narrowing. `np.sort(...)` is now reported as
`ndarray[tuple[Any, ...], dtype[Any]]` instead of being assignable to
`Sequence[np.datetime64]`, breaking the return type of
`get_unique_sorted_dates` in `src/pybroker/common.py`.

This PR fixes typecheck with a single-line `cast()` at the return site,
preserving the `Sequence[np.datetime64]` contract that downstream callers
(`IndicatorScope`, `Logger`, `ModelsMixin`) already depend on, with no
cascading signature churn.

Also bumps `setup.cfg [mypy] python_version` from `3.9` to `3.11`. Python
3.9 and 3.10 were removed from the test matrix in afc137b, and mypy 2.0
emits a warning that `3.9` is unsupported. This change only affects what
mypy assumes during static analysis — the library has no `python_requires`
declared, so this does not change runtime support.

## Why a `cast` rather than a stricter return annotation

I tried tightening the return annotation to `NDArray[np.datetime64]`. mypy
then surfaced 3 cascading errors at the call sites
(`model.py:330`, `strategy.py:185`, `strategy.py:241`) because `IndicatorScope`,
`Logger.train_split_start`, and `Logger.backtest_executions_start` all accept
`Sequence[np.datetime64]`. The `cast` keeps the diff to two files / 3+/3-
and preserves runtime behavior exactly (`np.ndarray` already walks/quacks
like a `Sequence` for the operations callers perform — iteration, `len()`,
indexing).

## Test plan

- [x] `tox -e typecheck` — Success: no issues found in 17 source files
- [x] `tox -e py312` — 4067 passed
- [x] `tox -e format,lint` — clean
- [x] Fork CI on `Pirat83/pybroker` — green on all jobs ([run 25503382766](https://github.com/Pirat83/pybroker/actions/runs/25503382766))
- [ ] Upstream Package CI (3.11 / 3.12 / 3.13) on this PR
- [ ] Upstream ASV Benchmarks (PR) — expected no regression (cast is a runtime no-op)

## Notes

- `tox.ini` left unchanged — pinning `mypy<2` would just defer the same
  triage to the next major upgrade, and the source fix is durable.
- Node 20 deprecation warnings on `actions/checkout@v4` etc. are out of
  scope here (already addressed on a separate branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)