### PR TITLE
Add ExitOnLastBarPreprocess ASV bench (regression guard for #240's preprocessing path)

### DIFF
--- a/benchmarks/bench_backtest.py
+++ b/benchmarks/bench_backtest.py
@@ -248,6 +248,85 @@ class WalkforwardLarge:
         )
 
 
+class _PreprocessOnlyStrategy(Strategy):
+    """Strategy whose ``walkforward_split`` yields zero windows.
+
+    Used by ``ExitOnLastBarPreprocess`` to isolate the
+    ``exit_on_last_bar`` preprocessing block in
+    :py:meth:`Strategy._run_walkforward`: the preprocessing fires before
+    the windows loop, and the loop becomes a no-op so the timed call
+    doesn't pay for trade simulation.
+    """
+
+    def walkforward_split(  # type: ignore[override]
+        self,
+        df: pd.DataFrame,
+        windows: int,
+        lookahead: int,
+        train_size: float = 0.9,
+        shuffle: bool = False,
+    ):
+        return iter(())
+
+
+def _exit_on_last_bar_noop_fn(_ctx: ExecContext) -> None:
+    pass
+
+
+class ExitOnLastBarPreprocess:
+    """Bench the ``exit_on_last_bar`` preprocessing block in
+    ``Strategy._run_walkforward``.
+
+    When ``exit_on_last_bar=True``, ``_run_walkforward`` builds a
+    ``{symbol: max_date}`` map before the windows loop fires. A naive
+    ``O(E*S*N)`` boolean-mask-per-symbol implementation can be replaced
+    by a single ``isin`` + ``groupby(symbol).max()``; this bench
+    quantifies the difference and catches future regressions.
+
+    Isolation strategy: ``_PreprocessOnlyStrategy.walkforward_split``
+    yields nothing, so the timed call exercises ``_filter_dates``,
+    indicator setup (empty here), and the preprocessing block, then
+    short-circuits before the windows loop.
+
+    Parametrized on ``n_symbols`` so the linear vs roughly quadratic
+    scaling shape is visible per-row in the asv-pr output.
+    """
+
+    timeout = 300
+    params = [50, 200, 500]
+    param_names = ("n_symbols",)
+
+    def setup(self, n_symbols: int) -> None:
+        np.random.seed(SEED)
+        self.df = _synthetic_ohlcv(n_symbols=n_symbols, n_days=252, seed=SEED)
+        self._build_strategy().walkforward(
+            windows=1,
+            lookahead=LOOKAHEAD,
+            calc_bootstrap=False,
+            disable_parallel=True,
+        )
+
+    def time_exit_on_last_bar_preprocess(self, n_symbols: int) -> None:
+        self._build_strategy().walkforward(
+            windows=1,
+            lookahead=LOOKAHEAD,
+            calc_bootstrap=False,
+            disable_parallel=True,
+        )
+
+    def _build_strategy(self) -> "_PreprocessOnlyStrategy":
+        pybroker.clear_params()
+        pybroker.disable_logging()
+        pybroker.disable_progress_bar()
+        symbols = sorted(self.df["symbol"].unique().tolist())
+        start = self.df["date"].min().strftime("%Y-%m-%d")
+        end = self.df["date"].max().strftime("%Y-%m-%d")
+        config = StrategyConfig(exit_on_last_bar=True)
+        strategy = _PreprocessOnlyStrategy(self.df, start, end, config)
+        strategy.add_execution(_exit_on_last_bar_noop_fn, symbols=symbols)
+        return strategy
+
+
 # ---------------------------------------------------------------------------
 # Group B — subsystem micro-benches (no vector dependency)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `ExitOnLastBarPreprocess` to `benchmarks/bench_backtest.py` — an
asv micro-bench for the `exit_on_last_bar` preprocessing block in
`Strategy._run_walkforward`.

It uses a `_PreprocessOnlyStrategy` subclass whose `walkforward_split`
yields zero windows, so the timed call exercises only `_filter_dates`,
indicator setup (empty here), and the preprocessing block, then
short-circuits before the windows loop. Trade simulation isn't paid
for, so the timing isolates the preprocessing cost cleanly.

Parametrized on `n_symbols=[50, 200, 500]` × 252 trading days. Single
file change, +83 / -0 lines, no functional changes outside `benchmarks/`.

## Why

#240 (open) replaces the `O(E*S*N)` nested boolean-mask loop in this
preprocessing path with a single `isin` + `groupby(symbol).max()`. Local
validation (cherry-picking #240's `strategy.py` change onto `dev` and
running `asv continuous`) shows:

| n_symbols | Before (dev) | After (dev + #240) | Ratio | Speedup |
|---|---|---|---|---|
| 50 | 150 ms | 24.0 ms | 0.16 | **6.3×** |
| 200 | 2.04 s | 41.7 ms | 0.02 | **49×** |
| 500 | 10.7 s | 52.7 ms | 0.00 | **~203×** |

`SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY. PERFORMANCE INCREASED.`

The bench is independently useful as a regression guard for this code
path — if a future change drifts away from the groupby pattern, the
asv-pr workflow's `--factor 1.1` threshold would catch it on every PR
that touches `_run_walkforward`. Adding the bench now makes the speedup
from #240 immediately visible in its asv-pr run once that PR retargets
to `dev` (or merges via the master→dev cycle).

## Expected asv-pr behavior on *this* PR

This PR's asv-pr run will compare `origin/dev` (baseline, no bench)
against HEAD (dev + bench). On `origin/dev` the bench file doesn't
exist yet, so asv has nothing to compare against on the base side and
just reports the HEAD timings (the slow numbers, since `dev` still has
the pre-#240 implementation):

```
n_symbols=50  ~150 ms
n_symbols=200 ~2.0 s
n_symbols=500 ~10 s
```

That's expected and correct — this PR adds infrastructure, not a perf
change. The speedup signal arrives the moment #240 (or an equivalent)
lands on `dev`.

## Etiquette / coordination with #240

This PR does **not** include the `strategy.py` change from #240 — that
remains the author's contribution (`@quant9527`). Once #240 merges,
this bench's `asv continuous` output on subsequent PRs will surface
the speedup automatically.

If this PR lands first (before #240), the bench just sits there
catching the slow path until #240 merges; no harm.

If #240 lands first and `@quant9527` includes a similar bench in his
PR, this one can be closed as redundant — no work lost, the bench
class can be diff'd against whatever lands.

## Test plan

- [ ] `asv check` reports "No problems found" — confirmed locally
- [ ] asv-pr workflow discovers the bench on HEAD and produces a
      sticky comment with the timings
- [ ] No other tests are touched; the bench doesn't run during the
      normal `pytest` suite (it's an asv-only file under `benchmarks/`)

## Local validation log

`asv continuous origin/dev HEAD --bench ExitOnLastBarPreprocess --quick`
on a Linux 6.19 / Intel i7-7500U / 16 GB RAM machine produced the
table above. Full asv log on request; the PR-comment style summary
posted on edtechre/pybroker#240 has the same numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
