### PR TITLE
Add IndicatorPreprocess ASV bench (regression guard for indicator.py preprocessing)

### DIFF
--- a/benchmarks/bench_backtest.py
+++ b/benchmarks/bench_backtest.py
@@ -253,6 +253,55 @@ class WalkforwardLarge:
 # ---------------------------------------------------------------------------
 
 
+class IndicatorPreprocess:
+    """Bench :py:meth:`pybroker.indicator.IndicatorSet.__call__` on a
+    multi-symbol DataFrame.
+
+    Guards two per-symbol mask loops in ``indicator.py``:
+    ``IndicatorsMixin.compute_indicators`` slices ``df[df[symbol] ==
+    sym]`` once per uncached ``IndicatorSymbol`` and
+    ``IndicatorSet.__call__`` repeats the same boolean mask while
+    rebuilding the flat output frame. Both are ``O(S * N)`` per call
+    and collapse to a single ``groupby(symbol)`` pass.
+
+    Isolation: calling ``IndicatorSet(...)(df)`` directly exercises
+    both loops without any ``Strategy`` shim. Parametrized on
+    ``(n_symbols, n_indicators)`` so the linear-in-S scan cost and
+    the I-amplified rebuild cost both have a row that pins them.
+    """
+
+    timeout = 300
+    params = ([50, 200, 500], [1, 5])
+    param_names = ("n_symbols", "n_indicators")
+
+    def setup(self, n_symbols: int, n_indicators: int) -> None:
+        from pybroker.indicator import IndicatorSet
+        from pybroker.vect import highv, lowv, sumv
+
+        np.random.seed(SEED)
+        pybroker.clear_params()
+        pybroker.disable_logging()
+        pybroker.disable_progress_bar()
+        self.df = _synthetic_ohlcv(n_symbols=n_symbols, n_days=252, seed=SEED)
+        kernels = (
+            ("hhv20", lambda b: highv(b.close, 20)),
+            ("llv20", lambda b: lowv(b.close, 20)),
+            ("sum20", lambda b: sumv(b.close, 20)),
+            ("hhv50", lambda b: highv(b.close, 50)),
+            ("llv50", lambda b: lowv(b.close, 50)),
+        )
+        ind_set = IndicatorSet()
+        for name, fn in kernels[:n_indicators]:
+            ind_set.add(pybroker.indicator(name, fn))
+        self._ind_set = ind_set
+        self._ind_set(self.df, disable_parallel=True)
+
+    def time_indicator_set_call(
+        self, n_symbols: int, n_indicators: int
+    ) -> None:
+        self._ind_set(self.df, disable_parallel=True)
+
+
 class IndicatorKernels:
     """Direct calls into vect.py @njit kernels.
 


### PR DESCRIPTION
## Summary

Adds a single ASV bench class, `IndicatorPreprocess`, that times `pybroker.indicator.IndicatorSet.__call__` on a multi-symbol DataFrame. Calling `IndicatorSet(...)(df)` directly exercises **two** per-symbol mask loops in `indicator.py` without any `Strategy` shim:

- `IndicatorsMixin.compute_indicators` — slices `df[df[symbol] == sym]` once per uncached `IndicatorSymbol`.
- `IndicatorSet.__call__` — repeats the same boolean mask while rebuilding the flat output frame.

Both are `O(S * N)` per call where `S` is the symbol count and `N` is the row count, and both collapse to a single `groupby(symbol)` pass. This bench quantifies that potential difference and leaves a regression guard in CI for the indicator path that the existing `Walkforward*` benches don't cover (they warm up indicator computation in `setup` so the timed step skips it).

The follow-up vectorization is opened as a sibling PR; this bench is intentionally landed first so the comparison is clean once the refactor is reviewed.

### Param matrix

`params = ([50, 200, 500], [1, 5])` → 6 cells. `n_symbols=500` is where the boolean-mask cost dominates; `n_indicators=1` isolates the compute loop, `n_indicators=5` amplifies the rebuild loop's `extend(series.values)` cost. `n_days=252` matches `ExitOnLastBarPreprocess` (#242) — these loops scale in `S`, not `N`.

### Baseline timings (today's code, `--quick`)

| n_symbols | n_indicators=1 | n_indicators=5 |
|-----------|----------------|----------------|
| 50        | 235 ms         | 276 ms         |
| 200       | 4.26 s         | 3.60 s         |
| 500       | 15.6 s         | 15.1 s         |

These will appear in the asv-pr sticky comment as the new baseline.

### Naming + style

`IndicatorPreprocess` pairs cleanly with the sibling `IndicatorKernels` in Group B (subsystem micro-benches), inserted immediately before it. `time_indicator_set_call` matches the `time_<thing>` naming convention used by `time_walkforward_scaled` / `time_exit_on_last_bar_preprocess`. Imports inside `setup` mirror `IndicatorKernels` / `EvalKernels`.

## Test plan

- [x] `asv check` — bench class collects cleanly.
- [x] `asv run --bench IndicatorPreprocess --quick HEAD^!` — every cell completes successfully within `timeout=300`.
- [x] `tox -e format -- --check` — formatted.
- [x] `tox -e lint` — no lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)