### PR TITLE
perf: vectorize per-symbol mask loops in indicator.py (groupby)

### DIFF
--- a/src/pybroker/indicator.py
+++ b/src/pybroker/indicator.py
@@ -214,16 +214,21 @@ class IndicatorsMixin:
             scope.logger.info_loaded_indicator_data(indicator_data.keys())
         scope.logger.indicator_data_start(uncached_ind_syms)
         scope.logger.info_indicator_data_start(uncached_ind_syms)
-        sym_data: dict[str, dict[str, Optional[NDArray]]] = defaultdict(dict)
-        for _, sym in uncached_ind_syms:
-            if sym in sym_data:
+        needed_syms = {sym for _, sym in uncached_ind_syms}
+        sym_data: dict[str, dict[str, Optional[NDArray]]] = {}
+        for sym, group in df.groupby(
+            DataCol.SYMBOL.value, sort=False, observed=True
+        ):
+            if sym not in needed_syms:
                 continue
-            data = df[df[DataCol.SYMBOL.value] == sym]
-            for col in scope.all_data_cols:
-                if col not in data.columns:
-                    sym_data[sym][col] = None
-                    continue
-                sym_data[sym][col] = data[col].to_numpy(copy=True)
+            sym_data[sym] = {
+                col: (
+                    group[col].to_numpy(copy=True)
+                    if col in group.columns
+                    else None
+                )
+                for col in scope.all_data_cols
+            }
         for i, (ind_sym, series) in enumerate(
             self._run_indicators(sym_data, uncached_ind_syms, disable_parallel)
         ):
@@ -381,9 +386,15 @@ class IndicatorSet(IndicatorsMixin):
         sym_dict: dict[str, dict[str, pd.Series]] = defaultdict(dict)
         for ind_sym, series in ind_dict.items():
             sym_dict[ind_sym.symbol][ind_sym.ind_name] = series
+        date_by_sym = {
+            sym: group[DataCol.DATE.value]
+            for sym, group in df.groupby(
+                DataCol.SYMBOL.value, sort=False, observed=True
+            )
+        }
         data: dict[str, list] = defaultdict(list)
         for sym, ind_series in sym_dict.items():
-            dates = df[df[DataCol.SYMBOL.value] == sym][DataCol.DATE.value]
+            dates = date_by_sym[sym]
             data[DataCol.SYMBOL.value].extend(
                 itertools.repeat(sym, len(dates))
             )


### PR DESCRIPTION
## Summary

Same vectorization principle PR #240 applied to `Strategy._run_walkforward`'s `exit_on_last_bar` preprocessing — replace nested per-symbol DataFrame masks with a single `df.groupby(symbol)` pass — applied to two more locations in `indicator.py`:

1. **`IndicatorsMixin.compute_indicators`** (lines 217-226 on dev) — was iterating `uncached_ind_syms` and slicing `df[df[symbol] == sym]` per entry, deduping by `if sym in sym_data`. Now: dedupe to `needed_syms` set, iterate `df.groupby(symbol, sort=False)` once, populate the per-symbol column dict via comprehension.
2. **`IndicatorSet.__call__`** (lines 384-393 on dev) — was repeating the same boolean mask to extract per-symbol dates while rebuilding the flat output. Now: precompute a `{sym: dates}` lookup via one `groupby` pass, then look up dates while iterating `sym_dict.items()` (preserving the original iteration order so the output's row order is bit-identical).

No new imports. No new helpers — the two loops do different things and sharing one obscures intent.

## Speedup (asv-continuous --quick, n_days=252)

Bench from #244 (cherry-picked locally onto both refs for this measurement).

| Change | Before [dev]   | After [HEAD]   | Ratio | Benchmark                                                        |
|--------|----------------|----------------|-------|------------------------------------------------------------------|
| -      | 235 ms         | 150 ms         | 0.64  | IndicatorPreprocess.time_indicator_set_call(50, 1)               |
| -      | 276 ms         | 189 ms         | 0.68  | IndicatorPreprocess.time_indicator_set_call(50, 5)               |
| -      | 4.26 s         | 383 ms         | 0.09  | IndicatorPreprocess.time_indicator_set_call(200, 1)              |
| -      | 3.60 s         | 646 ms         | 0.18  | IndicatorPreprocess.time_indicator_set_call(200, 5)              |
| -      | 15.6 s         | 1.40 s         | 0.09  | IndicatorPreprocess.time_indicator_set_call(500, 1)              |
| -      | 15.1 s         | 1.68 s         | 0.11  | IndicatorPreprocess.time_indicator_set_call(500, 5)              |

That's ~9–11× at `n_symbols=500`. Once #244 lands on dev, the asv-pr workflow on this PR will post its own table against the pre-refactor baseline.

## Why semantics are preserved

- `groupby(sort=False)` only affects the order group keys are yielded — rows within each group retain their original df order, same as boolean-mask filtering.
- `to_numpy(copy=True)` semantics unchanged.
- `IndicatorSet.__call__` iterates `sym_dict.items()` (not `df.groupby` directly) so the per-symbol block ordering in the flat output matches today's behavior; the groupby is only used to build a lookup dict.
- Output column ordering preserved (first-iteration dict insertion order is identical: `[symbol, date, *ind_names]`).
- `needed_syms` / `if sym not in sym_dict` filters mirror today's implicit contract that every requested symbol is present in df (both `uncached_ind_syms` and `sym_dict` originate from `df[symbol].unique()`).

## Coordination with sibling PRs

- **#244** — adds the `IndicatorPreprocess` ASV bench used to measure the speedup above. Should land first so the asv-pr workflow on this PR has the bench available; this PR's body table was produced locally by cherry-picking #244 onto both refs.
- **#246** — adds a focused multi-symbol test for `IndicatorSet.__call__` that pins per-symbol row contiguity, date order, and numeric values. Catches the kinds of mistakes a row-shuffling refactor could introduce; passes on both today's code and this PR's refactor. Independent from this PR, but a useful safety net.

No conflict with any open PR (#240 = strategy.py, #241 = mypy fix, #242/#243 = bench/test for the `exit_on_last_bar` work, #244 = this bench).

## Test plan

- [x] `tox -e py312 -- tests/test_indicator.py tests/test_strategy.py` — 2564 tests pass.
- [x] `tox -e format -- --check` — formatted.
- [x] `tox -e lint` — no lint errors.
- [x] Local `asv continuous` against `dev`+bench — speedup table above.
- [ ] CI: full test matrix on PR.
- [ ] CI: asv-pr workflow once #244 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)