### PR TITLE
test: pin per-symbol layout and values in IndicatorSet.__call__

### DIFF
--- a/tests/test_indicator.py
+++ b/tests/test_indicator.py
@@ -253,6 +253,44 @@ class TestIndicatorSet:
         assert len(result) == len(df)
         assert set(result.columns) == set(["date", "symbol", "hhv", "llv"])
 
+    def test_call_per_symbol_layout_and_values(
+        self, data_source_df, hhv_ind, llv_ind, disable_parallel
+    ):
+        ind_set = IndicatorSet()
+        ind_set.add([hhv_ind, llv_ind])
+        result = ind_set(data_source_df, disable_parallel)
+
+        sym_col = DataCol.SYMBOL.value
+        date_col = DataCol.DATE.value
+
+        assert list(result.columns) == [sym_col, date_col, "hhv", "llv"]
+        assert len(result) == len(data_source_df)
+
+        syms_in_output = result[sym_col].unique().tolist()
+        assert set(syms_in_output) == set(
+            data_source_df[sym_col].unique().tolist()
+        )
+        sym_blocks = result[sym_col].ne(result[sym_col].shift()).cumsum()
+        assert sym_blocks.nunique() == len(syms_in_output)
+
+        for sym in syms_in_output:
+            sym_rows = result[result[sym_col] == sym].reset_index(drop=True)
+            sym_input = data_source_df[
+                data_source_df[sym_col] == sym
+            ].reset_index(drop=True)
+
+            assert len(sym_rows) == len(sym_input)
+            pd.testing.assert_series_equal(
+                sym_rows[date_col],
+                sym_input[date_col],
+                check_names=False,
+            )
+
+            for ind in (hhv_ind, llv_ind):
+                expected = ind(sym_input).to_numpy()
+                actual = sym_rows[ind.name].to_numpy()
+                np.testing.assert_array_equal(actual, expected)
+
 
 @pytest.mark.parametrize(
     "fn, values, period, expected",


### PR DESCRIPTION
## Summary

The existing \`TestIndicatorSet::test_call\` only asserts \`len(result) == len(df)\` and the column set, so a refactor that scrambles per-symbol row ordering, misaligns dates, or returns wrong indicator values would slip through silently. A coverage audit while preparing #245 surfaced this gap.

Add `test_call_per_symbol_layout_and_values` covering:

- Column order is `[symbol, date, *ind_names]` (pin the dict-insertion contract).
- Each symbol's rows are contiguous in the flat output (no interleaving across symbols).
- Per-symbol date sequence matches the input DataFrame's row order for that symbol.
- Per-symbol indicator values match an independent `Indicator(...)` invocation on the per-symbol slice — catches any misalignment between dates and series values.

Reuses existing fixtures (`data_source_df`, `hhv_ind`, `llv_ind`) and the parametrized `disable_parallel` fixture so both serial and parallel paths are exercised.

The test passes on **both** today's `dev` and the refactor in #245 — this is a true coverage addition, not a refactor-only check.

## Coordination with sibling PRs

- **#244** — adds the `IndicatorPreprocess` ASV bench (regression guard for the same loops this test pins).
- **#245** — vectorizes the two per-symbol mask loops in `indicator.py` that this test guards. This test is the correctness counterpart to that PR's perf work and would fail loudly on a buggy vectorization (e.g., one that drops `sort=False`, scrambles iteration order, or misaligns `series.values` with dates).

Independent from #244 and #245 — can land in any order.

## Test plan

- [x] `tox -e py312 -- tests/test_indicator.py::TestIndicatorSet` — passes on dev (9 tests, both \`disable_parallel=True\` and \`False\`).
- [x] Same suite passes when test is cherry-picked onto #245's refactor branch — 2 new test parametrizations green.
- [x] `tox -e format -- --check` — formatted.
- [x] `tox -e lint` — no lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)