### PR TITLE
Add FXMacroData data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ your strategy’s performance.
 
 - A super-fast backtesting engine built in [NumPy](https://numpy.org/) and accelerated with [Numba](https://numba.pydata.org/).
 - The ability to create and execute trading rules and models across multiple instruments with ease.
-- Access to historical data from [Alpaca](https://alpaca.markets/), [Yahoo Finance](https://finance.yahoo.com/), [AKShare](https://github.com/akfamily/akshare), or from [your own data provider](https://www.pybroker.com/en/latest/notebooks/7.%20Creating%20a%20Custom%20Data%20Source.html).
+- Access to historical data from [Alpaca](https://alpaca.markets/), [Yahoo Finance](https://finance.yahoo.com/), [AKShare](https://github.com/akfamily/akshare), [FXMacroData](https://fxmacrodata.com/), or from [your own data provider](https://www.pybroker.com/en/latest/notebooks/7.%20Creating%20a%20Custom%20Data%20Source.html).
 - The option to train and backtest models using [Walkforward Analysis](https://www.pybroker.com/en/latest/notebooks/6.%20Training%20a%20Model.html#Walkforward-Analysis), which simulates how the strategy would perform during actual trading.
 - More reliable trading metrics that use randomized [bootstrapping](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)) to provide more accurate results.
 - Caching of downloaded data, indicators, and models to speed up your development process.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,7 +78,7 @@ Key Features
 
 * A super-fast backtesting engine built in `NumPy <https://numpy.org/>`_  and accelerated with `Numba <https://numba.pydata.org/>`_.
 * The ability to create and execute trading rules and models across multiple instruments with ease.
-* Access to historical data from `Alpaca <https://alpaca.markets/>`_, `Yahoo Finance <https://finance.yahoo.com/>`_, `AKShare <https://github.com/akfamily/akshare>`_, or from `your own data provider <https://www.pybroker.com/en/latest/notebooks/7.%20Creating%20a%20Custom%20Data%20Source.html>`_.
+* Access to historical data from `Alpaca <https://alpaca.markets/>`_, `Yahoo Finance <https://finance.yahoo.com/>`_, `AKShare <https://github.com/akfamily/akshare>`_, `FXMacroData <https://fxmacrodata.com/>`_, or from `your own data provider <https://www.pybroker.com/en/latest/notebooks/7.%20Creating%20a%20Custom%20Data%20Source.html>`_.
 * The option to train and backtest models using `Walkforward Analysis <https://www.pybroker.com/en/latest/notebooks/6.%20Training%20a%20Model.html#Walkforward-Analysis>`_, which simulates how the strategy would perform during actual trading.
 * More reliable trading metrics that use randomized `bootstrapping <https://en.wikipedia.org/wiki/Bootstrapping_(statistics)>`_ to provide more accurate results.
 * Caching of downloaded data, indicators, and models to speed up your development process.

--- a/src/pybroker/ext/data.py
+++ b/src/pybroker/ext/data.py
@@ -194,7 +194,7 @@ class FXMacroData(DataSource):
     def __init__(
         self,
         api_key: Optional[str] = None,
-        base_url: str = "https://api.fxmacrodata.com/v1",
+        base_url: str = "https://fxmacrodata.com/api/v1",
         timeout: float = 30,
     ):
         super().__init__()

--- a/src/pybroker/ext/data.py
+++ b/src/pybroker/ext/data.py
@@ -7,7 +7,11 @@ This code is licensed under Apache 2.0 with Commons Clause license
 """
 
 from datetime import datetime
+import json
+import os
 from typing import Optional
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 import akshare
 import pandas as pd
@@ -169,3 +173,138 @@ class YQuery(DataSource):
             ]
         ]
         return df
+
+
+class FXMacroData(DataSource):
+    r"""Retrieves daily FX spot rates from
+    `FXMacroData <https://fxmacrodata.com/>`_."""
+
+    _columns = [
+        DataCol.DATE.value,
+        DataCol.SYMBOL.value,
+        DataCol.OPEN.value,
+        DataCol.HIGH.value,
+        DataCol.LOW.value,
+        DataCol.CLOSE.value,
+        DataCol.VOLUME.value,
+    ]
+    _env_api_keys = ("FXMACRODATA_API_KEY", "FXMD_API_KEY")
+    _supported_timeframes = {"", "1day"}
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.fxmacrodata.com/v1",
+        timeout: float = 30,
+    ):
+        super().__init__()
+        self.api_key = api_key or self._get_env_api_key()
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _fetch_data(
+        self,
+        symbols: frozenset[str],
+        start_date: datetime,
+        end_date: datetime,
+        timeframe: Optional[str],
+        adjust: Optional[bool],
+    ) -> pd.DataFrame:
+        """:meta private:"""
+        if timeframe not in self._supported_timeframes:
+            raise ValueError(
+                "FXMacroData only supports daily data; use timeframe='1d' "
+                "or leave it empty."
+            )
+        result = pd.DataFrame()
+        for symbol in symbols:
+            base, quote = self._parse_symbol(symbol)
+            payload = self._get_json(base, quote, start_date, end_date)
+            rows = payload.get("data", []) if isinstance(payload, dict) else []
+            rows_df = self._rows_to_df(symbol, rows)
+            result = pd.concat([result, rows_df], ignore_index=True)
+        if result.empty:
+            return self._empty_df()
+        result = result.sort_values(
+            by=[DataCol.SYMBOL.value, DataCol.DATE.value]
+        )
+        return result.reset_index(drop=True)
+
+    @classmethod
+    def _get_env_api_key(cls) -> Optional[str]:
+        for name in cls._env_api_keys:
+            api_key = os.getenv(name)
+            if api_key:
+                return api_key
+        return None
+
+    @staticmethod
+    def _parse_symbol(symbol: str) -> tuple[str, str]:
+        clean_symbol = symbol.strip().upper()
+        if clean_symbol.endswith("=X"):
+            clean_symbol = clean_symbol[:-2]
+        clean_symbol = clean_symbol.replace("/", "")
+        clean_symbol = clean_symbol.replace("-", "")
+        clean_symbol = clean_symbol.replace("_", "")
+        if len(clean_symbol) != 6 or not clean_symbol.isalpha():
+            raise ValueError(
+                "FXMacroData symbols must be currency pairs such as "
+                "'EURUSD' or 'EUR/USD'."
+            )
+        return clean_symbol[:3].lower(), clean_symbol[3:].lower()
+
+    @classmethod
+    def _empty_df(cls) -> pd.DataFrame:
+        return pd.DataFrame(columns=cls._columns)
+
+    def _get_json(
+        self,
+        base: str,
+        quote: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> dict:
+        params = urlencode(
+            {
+                "start_date": to_datetime(start_date).strftime("%Y-%m-%d"),
+                "end_date": to_datetime(end_date).strftime("%Y-%m-%d"),
+            }
+        )
+        url = f"{self.base_url}/forex/{base}/{quote}?{params}"
+        request = Request(url)
+        if self.api_key:
+            request.add_header("X-API-Key", self.api_key)
+        with urlopen(request, timeout=self.timeout) as response:
+            content = response.read().decode("utf-8")
+        return json.loads(content)
+
+    @classmethod
+    def _rows_to_df(cls, symbol: str, rows: list[dict]) -> pd.DataFrame:
+        result = []
+        for row in rows:
+            date = row.get("date")
+            rate = cls._get_rate(row)
+            if date is None or rate is None:
+                continue
+            result.append(
+                {
+                    DataCol.DATE.value: pd.to_datetime(date),
+                    DataCol.SYMBOL.value: symbol,
+                    DataCol.OPEN.value: rate,
+                    DataCol.HIGH.value: rate,
+                    DataCol.LOW.value: rate,
+                    DataCol.CLOSE.value: rate,
+                    DataCol.VOLUME.value: 0,
+                }
+            )
+        if not result:
+            return cls._empty_df()
+        return pd.DataFrame(result, columns=cls._columns)
+
+    @staticmethod
+    def _get_rate(row: dict) -> Optional[float]:
+        for key in ("val", "value", "close", "rate"):
+            value = row.get(key)
+            if value is not None:
+                return float(value)
+        return None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ This code is licensed under Apache 2.0 with Commons Clause license
 """
 
 import akshare
+import json
 import os
 import pandas as pd
 import pytest
@@ -23,6 +24,7 @@ from pybroker.data import (
     YFinance,
 )
 from pybroker.ext.data import AKShare
+from pybroker.ext.data import FXMacroData
 from pybroker.ext.data import YQuery
 from unittest import mock
 from yahooquery import Ticker
@@ -45,6 +47,29 @@ ALPACA_COLS = [
     "vwap",
 ]
 ALPACA_CRYPTO_COLS = ALPACA_COLS + ["trade_count"]
+FXMACRODATA_COLS = [
+    "date",
+    "symbol",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+]
+
+
+class FXMacroDataResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
 
 
 @pytest.fixture()
@@ -777,3 +802,87 @@ class TestYQuery:
                 Ticker, "history", return_value=expected_df
             ):
                 yq.query(symbols, START_DATE, END_DATE, "90m")
+
+
+class TestFXMacroData:
+    @pytest.mark.usefixtures("setup_ds_cache")
+    def test_query(self):
+        fxmd = FXMacroData(
+            api_key=API_KEY, base_url="https://example.com/v1"
+        )
+        payload = {
+            "data": [
+                {"date": "2021-02-02", "val": "1.201"},
+                {"date": "2021-02-03", "val": 1.202},
+            ]
+        }
+        with mock.patch(
+            "pybroker.ext.data.urlopen",
+            return_value=FXMacroDataResponse(payload),
+        ) as mock_urlopen:
+            df = fxmd.query(["EUR/USD"], START_DATE, END_DATE, "1d")
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == (
+            "https://example.com/v1/forex/eur/usd?"
+            "start_date=2021-02-02&end_date=2022-02-02"
+        )
+        assert dict(request.header_items())["X-api-key"] == API_KEY
+        assert mock_urlopen.call_args.kwargs["timeout"] == 30
+        assert set(df.columns) == set(FXMACRODATA_COLS)
+        assert df.shape[0] == 2
+        assert df["symbol"].tolist() == ["EUR/USD", "EUR/USD"]
+        assert df["close"].tolist() == [1.201, 1.202]
+        assert df["open"].tolist() == df["close"].tolist()
+        assert df["high"].tolist() == df["close"].tolist()
+        assert df["low"].tolist() == df["close"].tolist()
+        assert df["volume"].tolist() == [0, 0]
+        assert df["date"].tolist() == [
+            pd.Timestamp("2021-02-02"),
+            pd.Timestamp("2021-02-03"),
+        ]
+
+    @pytest.mark.usefixtures("setup_ds_cache")
+    def test_query_when_empty_result(self):
+        fxmd = FXMacroData(base_url="https://example.com/v1")
+        with mock.patch(
+            "pybroker.ext.data.urlopen",
+            return_value=FXMacroDataResponse({"data": []}),
+        ):
+            df = fxmd.query(["EURUSD"], START_DATE, END_DATE, "1d")
+        assert df.empty
+        assert set(df.columns) == set(FXMACRODATA_COLS)
+
+    def test_query_when_invalid_symbol_then_error(self):
+        fxmd = FXMacroData(base_url="https://example.com/v1")
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "FXMacroData symbols must be currency pairs such as "
+                "'EURUSD' or 'EUR/USD'."
+            ),
+        ):
+            fxmd.query(["EUR"], START_DATE, END_DATE, "1d")
+
+    def test_query_when_unsupported_timeframe_then_error(self):
+        fxmd = FXMacroData(base_url="https://example.com/v1")
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "FXMacroData only supports daily data; use timeframe='1d' "
+                "or leave it empty."
+            ),
+        ):
+            fxmd.query(["EURUSD"], START_DATE, END_DATE, "1h")
+
+    @pytest.mark.usefixtures("setup_ds_cache")
+    def test_query_uses_env_api_key(self, monkeypatch):
+        monkeypatch.delenv("FXMACRODATA_API_KEY", raising=False)
+        monkeypatch.setenv("FXMD_API_KEY", API_SECRET)
+        fxmd = FXMacroData(base_url="https://example.com/v1")
+        with mock.patch(
+            "pybroker.ext.data.urlopen",
+            return_value=FXMacroDataResponse({"data": []}),
+        ) as mock_urlopen:
+            fxmd.query(["EURUSD"], START_DATE, END_DATE, "1d")
+        request = mock_urlopen.call_args.args[0]
+        assert dict(request.header_items())["X-api-key"] == API_SECRET


### PR DESCRIPTION
## Summary
- Add an `FXMacroData` data source under `pybroker.ext.data` for daily FX spot history.
- Map FX spot rates to PyBroker-compatible OHLCV bars, using the same rate for open/high/low/close and `volume=0`.
- Document FXMacroData alongside the existing historical data source options.

## Validation
- `$env:PYTHONPATH = (Resolve-Path src).Path; python -m pytest tests\test_data.py -q`
- `python -m ruff check src tests`
- `git diff --check`