### PR TITLE
ci: add Dependabot version updates for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly version-update checks for:

- `pip` (`requirements.txt` / `setup.cfg` pins)
- `github-actions` (workflow action versions)

Both target `dev` to match the repo's normal PR convention.

**Motivation:** the `mypy` 2.x drift that broke the fork's `Schedule` CI a few weeks back (fixed in `bfd8172`) is exactly the kind of thing this catches automatically and early, instead of surfacing as a red scheduled build.

**Setup needed on your end: none for the file itself.** Dependabot version updates activate automatically once this file is on a branch it targets — no app install, no repo-settings toggle required for public repos.

One optional, separate thing if you ever want it: Dependabot *security* updates (auto-PRs for vulnerable dependencies flagged by the dependency graph) are a distinct feature from version updates and need a manual opt-in at **Settings → Code security → Dependabot → Dependabot alerts / Dependabot security updates**. Not required for this PR to work — just flagging it exists in case it's useful, since it's a separate switch from what this file does.

---

**Update — real-world evidence.** Enabled this same config on the fork to see what it actually produces before proposing it here. It opened 12 PRs (Pirat83/pybroker#9–#20). Rather than merge them blindly, triaged every one — see [#251](https://github.com/edtechre/pybroker/pull/251) for the skill built to do that properly. Two turned out to be real, currently-live bugs (fixed in [#250](https://github.com/edtechre/pybroker/pull/250) and [#252](https://github.com/edtechre/pybroker/pull/252)), two more looked cosmetic but were actually load-bearing fixes (Pirat83/pybroker#19, #15), and the rest came back genuinely safe with real verification evidence, not just a green checkmark, on each PR:

Pirat83/pybroker#9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20