### PR TITLE
fix: don't duplicate volume column in AKShare TX fallback

### DIFF
--- a/src/pybroker/ext/data.py
+++ b/src/pybroker/ext/data.py
@@ -103,23 +103,26 @@ class AKShare(DataSource):
             )
         if result.empty:
             return result
-        result.rename(
-            columns={
-                "日期": DataCol.DATE.value,
-                "开盘": DataCol.OPEN.value,
-                "收盘": DataCol.CLOSE.value,
-                "最高": DataCol.HIGH.value,
-                "最低": DataCol.LOW.value,
-                "成交量": DataCol.VOLUME.value,
-                "date": DataCol.DATE.value,
-                "open": DataCol.OPEN.value,
-                "close": DataCol.CLOSE.value,
-                "high": DataCol.HIGH.value,
-                "low": DataCol.LOW.value,
-                "amount": DataCol.VOLUME.value,
-            },
-            inplace=True,
-        )
+        rename_map = {
+            "日期": DataCol.DATE.value,
+            "开盘": DataCol.OPEN.value,
+            "收盘": DataCol.CLOSE.value,
+            "最高": DataCol.HIGH.value,
+            "最低": DataCol.LOW.value,
+            "成交量": DataCol.VOLUME.value,
+            "date": DataCol.DATE.value,
+            "open": DataCol.OPEN.value,
+            "close": DataCol.CLOSE.value,
+            "high": DataCol.HIGH.value,
+            "low": DataCol.LOW.value,
+        }
+        if DataCol.VOLUME.value not in result.columns:
+            # stock_zh_a_hist_tx pre-1.18.74 reported volume under "amount".
+            # Since then it returns its own "volume" column and "amount" is
+            # a distinct RMB turnover figure, so only remap the legacy alias
+            # when a real volume column isn't already present.
+            rename_map["amount"] = DataCol.VOLUME.value
+        result.rename(columns=rename_map, inplace=True)
         result["date"] = pd.to_datetime(result["date"])
         result = result[
             [

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -652,7 +652,11 @@ class TestAKShare:
         )
 
     @pytest.mark.usefixtures("setup_ds_cache")
-    def test_query_when_em_unavailable_then_uses_tx_fallback(self):
+    def test_query_when_em_unavailable_then_uses_tx_fallback_legacy_schema(
+        self,
+    ):
+        # akshare < 1.18.74: stock_zh_a_hist_tx reports volume under
+        # "amount" and has no dedicated "volume" column.
         symbols = ["000001.SZ"]
         ak = AKShare()
         expected_df = pd.DataFrame(
@@ -683,6 +687,7 @@ class TestAKShare:
             adjust="",
         )
         assert df.shape[0] == expected_df.shape[0]
+        assert list(df.columns).count("volume") == 1
         assert set(df.columns) == {
             "date",
             "open",
@@ -692,6 +697,53 @@ class TestAKShare:
             "volume",
             "symbol",
         }
+        assert df["volume"].iloc[0] == 5.0
+
+    @pytest.mark.usefixtures("setup_ds_cache")
+    def test_query_when_em_unavailable_then_uses_tx_fallback_current_schema(
+        self,
+    ):
+        # akshare >= 1.18.74: stock_zh_a_hist_tx added a real "volume"
+        # column and repurposed "amount"/"turnover" as distinct RMB
+        # figures, no longer standing in for volume. Regression guard for
+        # the rename map producing two "volume" columns.
+        symbols = ["000001.SZ"]
+        ak = AKShare()
+        expected_df = pd.DataFrame(
+            {
+                "date": [END_DATE.date()],
+                "open": [1.0],
+                "close": [2.0],
+                "high": [3.0],
+                "low": [4.0],
+                "volume": [6.0],
+                "turnover": [7.0],
+                "amount": [80000.0],
+            }
+        )
+        with (
+            mock.patch.object(
+                akshare,
+                "stock_zh_a_hist",
+                side_effect=ConnectionError("failed"),
+            ),
+            mock.patch.object(
+                akshare, "stock_zh_a_hist_tx", return_value=expected_df
+            ),
+        ):
+            df = ak.query(symbols, START_DATE, END_DATE, "1d")
+        assert df.shape[0] == expected_df.shape[0]
+        assert list(df.columns).count("volume") == 1
+        assert set(df.columns) == {
+            "date",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "symbol",
+        }
+        assert df["volume"].iloc[0] == 6.0
 
     @pytest.mark.usefixtures("setup_ds_cache")
     def test_query_when_unsupported_timeframe_then_empty(self):


### PR DESCRIPTION
Small follow-up to `422fd72` ("Fixes Alpaca and AKShare data sources") — the AKShare TX fallback path (`stock_zh_a_hist_tx`, used when the primary EM source fails for daily bars) collides with a schema change akshare shipped around the same time.

**The bug:** as of akshare 1.18.74, `stock_zh_a_hist_tx` added a real `volume` column and repurposed `amount`/`turnover` as distinct RMB figures that no longer stand in for volume (previously `amount` was the only volume-like field). The fallback's rename map still does `"amount" -> "volume"` unconditionally, so on current akshare the result ends up with **two columns both named `volume`** — the real share count and the rescaled currency amount — instead of raising, it silently produces a malformed/duplicate-column frame.

Reproducible directly:
```python
import pandas as pd
df = pd.DataFrame({"date": ["x"], "open": [1.0], "close": [2.0], "high": [3.0],
                    "low": [4.0], "volume": [6.0], "turnover": [7.0], "amount": [80000.0]})
df.rename(columns={"amount": "volume"}, inplace=True)
list(df.columns).count("volume")  # -> 2
```

**Fix:** only remap the legacy `amount` alias when a real `volume` column isn't already present, so both the pre-1.18.74 and current TX schemas resolve to exactly one `volume` column.

Added two tests — one pinning the legacy schema (pre-1.18.74, `amount` as the only volume-like field) and one pinning the current schema (native `volume` + `amount`/`turnover`), each asserting `volume` appears exactly once. Confirmed the new test fails against the old rename logic (reproduced above) before the fix.