### PR TITLE
docs: contribute a Dependabot migration-triage Claude Code skill

### DIFF
--- a/.claude/skills/dependency-migration-triage/SKILL.md
+++ b/.claude/skills/dependency-migration-triage/SKILL.md
@@ -139,6 +139,22 @@ Phase 5 regression test. If something needs a genuinely new concept adopted (not
 find-replace), implement it, but flag in the PR description that this is a judgment call the
 maintainer may want to review more closely than a mechanical fix.
 
+**If this phase produced a real code change** (skip this entirely for a comment-only, nothing-
+to-fix outcome — running either of these against a no-op finding is pure overhead), close the
+loop on your own work before moving to Phase 7:
+
+- Run the `silent-failure-hunter` agent (from the `pr-review-toolkit` plugin, if available in
+  this environment — otherwise apply the same lens yourself: does the fix swallow an error
+  anywhere, degrade to a fallback without surfacing it, or introduce a new way for something
+  to fail quietly?) against the diff. This is the same failure class the whole skill exists to
+  catch in third-party dependencies — pointing it at your own fix before a maintainer sees it
+  is the same discipline turned inward, not a generic review step.
+- If the fix touches secrets, authentication, or a publish/release pipeline (long-lived
+  tokens, credential handling, OIDC/trusted-publishing config, CI steps that push artifacts
+  somewhere), run `/security-review` (or apply that scrutiny yourself if unavailable) before
+  proceeding. Skip this for everything else — most triages never go near credentials, and
+  running it by default would be blanket overhead for no signal.
+
 ## Phase 7 — Open a PR that mirrors the migration
 
 Open a PR (same repo/branch conventions as the rest of this project — check recent merged

--- a/.claude/skills/dependency-migration-triage/SKILL.md
+++ b/.claude/skills/dependency-migration-triage/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: dependency-migration-triage
+description: >
+  Rigorously triage a single Dependabot (or Renovate) dependency version-bump PR: pull the
+  real changelog/release notes across the full old->new version range (not the PyPI summary
+  blurb), map it against actual usage sites in this codebase, write a migration plan that
+  distinguishes API-signature changes from conceptual/behavioral ones (a version bump can
+  quietly change defaults or strictness with no signature change at all), verify whether
+  existing tests would actually catch a regression in that exact spot or merely execute the
+  line with stale data, write a regression test that fails on the old behavior when a real
+  issue is found, fix what's fixable, and open a PR mirroring the migration that links back
+  to the originating Dependabot PR. Use this whenever the user wants to review, assess,
+  migrate, or avoid "merging blindly" a Dependabot/Renovate PR; asks "what changed" or "what
+  needs to adapt" for a dependency bump; wants confidence a version bump is safe beyond "CI
+  is green"; or just pastes a Dependabot PR number/link and asks to check it out. Trigger
+  even for dependencies that look boring (docs tooling, linters, CI actions) — some of the
+  highest-value findings here come from bumps everyone assumes are safe.
+---
+
+# Dependency Migration Triage
+
+Request: **$ARGUMENTS** (a Dependabot PR number/URL, or a dependency name + old version ->
+new version)
+
+You're triaging one dependency version bump. The goal is not "does it still import" — it's
+"what actually changed underneath this version number, and does anything in *this* codebase
+need to adapt because of it." A green CI run on the bump PR itself is necessary but not
+sufficient: CI only proves the currently-selected checks still pass, and says nothing about
+whether those checks were ever capable of catching the specific thing that changed. Two real
+findings from this repo's own history illustrate why that distinction matters — read
+`references/case-studies.md` before Phase 3 if this is your first time running this skill,
+or whenever a phase result feels uncertain.
+
+Work through these phases in order. Scale depth to actual signal (see the "Right-size the
+investigation" note before Phase 1) — a trivial patch bump of a barely-used tool doesn't
+warrant the same effort as a 4-major-version jump of a runtime dependency, and pretending
+otherwise produces padded reports, not better decisions.
+
+## Phase 0 — Identify the bump
+
+Resolve the PR (or dependency name) to: package name, old version, new version, and where in
+the repo it's declared (`requirements.txt`, `setup.cfg`, `pyproject.toml`, `.github/workflows/*.yml`
+for Actions). If given a PR number, `gh pr view <n> --repo <owner>/<repo>` gets you the title
+and diff.
+
+**Right-size the investigation.** Before going deep, get a fast read on stakes:
+- Is this a runtime dependency (imported by `src/`) or dev/docs tooling only (linters, type
+  checkers, doc builders, CI actions)? Runtime deps that ship in the actual package deserve
+  more scrutiny than a docs-only tool nobody's users ever touch.
+- How big is the jump — a patch release, or several majors/many minors? Bigger jumps need
+  more changelog reading, not more assumption.
+- Does this repo's test suite even exercise the dependency's usage sites at all (see Phase
+  4)? If a dependency has zero test coverage today, that's itself a finding worth surfacing
+  regardless of whether this particular bump breaks anything.
+A one-line patch bump of an unused-by-default dev tool can reasonably get a light pass. A
+major-version bump of something `src/` imports directly cannot.
+
+## Phase 1 — Get the real changelog, not the PyPI blurb
+
+PyPI's description field and a Dependabot PR's auto-generated "Changelog" section are
+starting points, not the source of truth — they're often truncated, and they only show the
+*target* version's notes, not the full range you're crossing. Go to the dependency's actual
+GitHub repo and read the CHANGELOG.md / release notes / "what's new" docs covering **every**
+minor/major version between old and new (patch releases are usually folded into their minor
+version's notes — confirm this is true for the specific project rather than assuming). Use
+WebFetch/WebSearch. For a wide range, you don't need to quote every entry — you need to have
+actually read enough to know whether something in it touches what this repo uses.
+
+## Phase 2 — Map to actual usage
+
+Grep `src/`, `tests/`, and (if that's the *only* place the dependency shows up) `docs/`
+notebooks for every real call site — imports, function/class usage, config file settings
+that reference the tool. Don't reason from the dependency's own docs in the abstract; ground
+every claim in this codebase's actual call sites, with file:line references. If a dependency
+isn't used anywhere in `src/` or `tests/`, say so plainly — that changes everything
+downstream (see Phase 4).
+
+## Phase 3 — Migration plan: API changes AND conceptual/behavioral ones
+
+For each usage site found in Phase 2, cross-reference against Phase 1's changelog and
+classify: **safe as-is** / **trivial fix** (renamed param, deprecated arg, config key rename)
+/ **real code change needed** / **new concept to adopt**.
+
+The trap to avoid: only checking whether a function signature changed. Some of the most
+consequential changes in a version bump are changes to *default behavior* with no signature
+change at all — stricter type-checking defaults, changed numeric precision, a narrower
+default timeout, a schema a third-party API now returns that your code doesn't expect. Read
+`references/case-studies.md` for two concrete examples of exactly this class of bug in this
+repo's own history. Ask explicitly, for each usage site: "if I changed nothing in my code,
+could this dependency's new version make this line do something different than before?" —
+that question catches what a signature diff alone won't.
+
+## Phase 4 — Coverage check: does a test actually cover *this*, or just execute the line?
+
+For every usage site flagged as anything other than "safe as-is" in Phase 3, find the
+test(s) that exercise it and read them — don't just check whether coverage tooling marks the
+line as executed. Ask: does the test construct the *specific input/shape* that the changed
+behavior would affect, with *live* logic (or a mock/fixture reflecting the *new* reality), or
+does it pass with data/mocks that predate the change and therefore can't reveal a regression
+even though the line technically runs? A line at 100% coverage can still be worthless for
+catching this exact class of bug — `references/case-studies.md` has a worked example. This
+phase's output is not a percentage; it's a specific yes/no per flagged usage site, with
+reasoning.
+
+**When coverage turns out to be zero or inadequate — which is common for docs tooling, CI
+actions, and other things outside the test suite's reach — you have to become the coverage
+yourself, and that means verifying *both directions*, not just one.** The natural instinct is
+to check "does the new version work" and stop once it does. That only catches regressions; it
+silently misses the mirror case, where the *old* version was already broken and the bump is
+actually a load-bearing fix rather than a no-op. The only way to tell those apart is to run
+the exact same check against both versions and compare — if you're about to spend the effort
+building/executing something to confirm the new version is fine, spend the same few minutes
+running the identical check against the old version first. `references/case-studies.md`
+(case study 4) documents this skill catching itself getting this wrong: an earlier run
+verified the new version of a dependency built cleanly, concluded "safe, nothing to fix," and
+never noticed the old version actually crashed against the current environment — something a
+same-effort comparison against the old version would have caught immediately.
+
+## Phase 5 — Write a regression test, only when there's a real finding
+
+If Phase 3/4 turned up an actual breaking change with inadequate coverage: write a test that
+constructs the exact input/shape that exposes it, and **prove it's a real regression test, not
+a plausible-sounding one** — reproduce the old buggy behavior directly (revert your Phase 6
+fix locally, or hand-run the old logic in a scratch snippet) and confirm the new test fails
+against it, then reinstate the fix and confirm it passes. This is the difference between "I
+think this would have failed" and "I watched it fail."
+
+If Phase 3/4 found nothing wrong: say so and stop here. Don't manufacture a test to look
+thorough — a fabricated regression test for a non-issue is noise that looks like rigor, and
+future readers can't tell the difference between "this guards something real" and "this pads
+the diff" unless you're honest about which is which right now.
+
+## Phase 6 — Fix what's fixable
+
+Mechanical/trivial migrations (deprecation warnings, renamed parameters, config key renames,
+newly-required explicit arguments) get fixed inline as part of this same pass — don't leave
+free wins for a human to redo. Real breaking changes get a proper code fix paired with the
+Phase 5 regression test. If something needs a genuinely new concept adopted (not just a
+find-replace), implement it, but flag in the PR description that this is a judgment call the
+maintainer may want to review more closely than a mechanical fix.
+
+## Phase 7 — Open a PR that mirrors the migration
+
+Open a PR (same repo/branch conventions as the rest of this project — check recent merged
+PRs for the base branch, typically `dev`) containing the Phase 6 fix and Phase 5 test. The
+PR description must:
+- Link/reference the originating Dependabot PR number explicitly, so the maintainer can find
+  it from either direction.
+- State plainly what was *verified by executing something* (a test that really failed then
+  passed, a notebook actually run, `mypy`/`ruff` actually invoked with the new version)
+  versus what was *inferred from changelogs* — don't blur the two. If nothing needed fixing,
+  the PR (or a comment on the Dependabot PR, if a whole new PR would be empty) should say
+  plainly "verified — the following was checked and nothing needs to change," not stay
+  silent.
+- Let the maintainer choose their own depth: deep-review this PR, or just trust it and merge
+  the Dependabot PR directly.
+
+If this run is a **dry-run / calibration** (no real PR should be opened — e.g. while testing
+this skill itself), stop after producing the would-be PR title + body + diff, and say so
+explicitly instead of calling `gh pr create`.
+
+## A note on trusting static tools
+
+Lint/type-checker findings (ruff rules, mypy errors, security scanners) are hypotheses, not
+verdicts, until you've traced the actual dataflow. A rule can flag a pattern that's provably
+safe in context (e.g. a `zip()` over two sequences whose lengths are structurally guaranteed
+equal by their type definitions) — `references/case-studies.md` has a worked example of
+exactly this. Before calling anything a "bug" in your report, verify it against the real code
+path, not just the rule's generic description of what it usually catches.

--- a/.claude/skills/dependency-migration-triage/references/case-studies.md
+++ b/.claude/skills/dependency-migration-triage/references/case-studies.md
@@ -1,0 +1,103 @@
+# Case studies: what this skill exists to catch (and not overclaim)
+
+Three real findings from this repo, each illustrating a different failure mode the phases in
+SKILL.md are designed to catch. Read before Phase 3/4 if a result feels uncertain, or as a
+sanity check on your own findings before writing them up.
+
+## 1. Conceptual/behavioral change with no signature change (mypy)
+
+Two separate mypy version bumps broke this codebase's typecheck step with **zero config
+changes on this repo's side** — proof that a version bump can change what "correct" code
+looks like without touching any function signature this repo calls.
+
+- Commit `5d65b0c` ("Fix typecheck broken by mypy 2.0 ndarray narrowing"): mypy 2.0 reworked
+  how it narrows `numpy.ndarray` generic types. Code that had type-checked cleanly for years
+  suddenly didn't, because mypy got *more precise* about what it could prove — not because
+  any pybroker code changed.
+- Commit `bfd8172` ("Fix mypy 2.3 errors and pin mypy 2.3 release"): a second, unrelated
+  tightening — this time around how `@njit`-wrapped function return types
+  (`np.floating` vs `float`) flow through `Callable[...]` parameter matching.
+
+The lesson: when triaging a type-checker, linter, or any tool whose whole job is "decide
+whether code is correct," don't just check for removed functions or renamed parameters —
+ask whether the tool's *definition of correct* changed. Running the new version against the
+real codebase (Phase 3) is the only way to find this; changelog-reading alone under-reports
+it unless the changelog explicitly calls out "stricter narrowing" or similar, and even then
+you won't know which lines it touches without running it.
+
+Related, sharper finding from the same investigation: running `mypy --show-error-codes
+--warn-unused-ignores` (a flag this repo's own CI does *not* use) against the exact
+CI-pinned environment found that **18 of 32 existing `# type: ignore` suppressions were
+already dead** under the currently-pinned version — including two added by `bfd8172` itself,
+already stale again by the time they were checked. The generalizable lesson: don't just ask
+"does this pass," ask "would anything today catch drift going forward" — and if the answer
+is no (as it was here, since `--warn-unused-ignores` wasn't enabled), that's a finding in its
+own right, independent of the specific bump being triaged.
+
+## 2. Coverage illusion (akshare)
+
+`src/pybroker/ext/data.py`'s AKShare TX-fallback path renamed an incoming `"amount"` column
+to `"volume"` unconditionally. As of akshare 1.18.74, the TX API started returning its own
+real `"volume"` column, with `"amount"` repurposed as a distinct RMB figure — so the
+unconditional rename produced **two columns both named `"volume"`** after the bump, silently
+corrupting the output instead of raising.
+
+The existing test for this exact code path (`test_query_when_em_unavailable_then_uses_tx_fallback`,
+before the fix in PR #250) passed at 100% line coverage on every run, before and after the
+akshare bump — because it mocked the fallback API's return value using the **old** schema.
+The line executed every time; the mock never reflected the new reality, so the test could
+never have caught this regression no matter how many times it ran.
+
+The lesson (Phase 4): "this line has test coverage" and "a test here would catch a real
+regression" are different claims. The only way to tell them apart is to read what shape of
+data the test actually constructs and ask whether that shape still matches what the
+dependency's new version actually returns — not whether the assertion count is nonzero.
+
+Fixed in PR https://github.com/edtechre/pybroker/pull/250 — only remap the legacy `amount`
+alias when a real `volume` column isn't already present, plus two tests pinning both the old
+and new schema, each asserting `volume` appears exactly once (the literal thing that broke).
+
+## 3. Overclaiming a lint finding (ruff)
+
+`ruff`'s `B905` rule flagged `eval.py:1146` — `zip(("99.9%", "99%", "95%", "90%"), *metrics)`
+— for missing `strict=True`, which in general risks silently truncating data on a length
+mismatch. Read in isolation, that looks like a real bug and was initially reported as one.
+
+Tracing the actual dataflow showed it wasn't: `metrics` is a `DrawdownMetrics` NamedTuple
+containing two `DrawdownConfs` NamedTuples, both **hardcoded to exactly 4 fields** by their
+type definitions. The three operands being zipped are therefore *statically guaranteed*
+equal length — there is no code path where they could ever differ, so `B905`'s "silent
+truncation" concern doesn't apply here no matter what future code changes happen elsewhere.
+
+The lesson: a static/lint tool's finding describes a *pattern*, not a proof about this
+specific code. Before writing "X is a bug" in a report, trace where the actual values come
+from and confirm the failure mode the tool warns about is actually reachable. Getting this
+wrong in the other direction — dismissing a real finding as "probably fine" without tracing
+it — is just as much a failure of this phase; the discipline is doing the trace either way,
+not defaulting to belief or disbelief.
+
+## 4. Verifying only one direction (nbsphinx) — a miss this skill made against itself
+
+During this skill's own calibration, one run triaged an `nbsphinx` bump that had zero test or
+CI coverage (docs-tooling-only, nothing in the pipeline builds the docs). Correctly following
+Phase 4's instinct to become the coverage, it built the actual documentation with the *new*
+nbsphinx version, watched it succeed with zero warnings, and concluded "safe, nothing to
+fix" — a clean, confident verdict, arrived at by actually executing something rather than
+just reading a changelog.
+
+It was still wrong. A parallel run (no skill at all, just told to check the same PR) happened
+to build the docs with *both* the old and new versions to compare, and found the old version
+**crashes outright** against the currently-installed Sphinx (`sphinx.util.status_iterator`
+was removed from Sphinx; old nbsphinx still called it). The bump wasn't a no-op — it was the
+only thing keeping the documentation buildable at all. The skill-following run never
+discovered this because it only ever asked "does the new version work," never "was the old
+version already broken."
+
+The lesson (why Phase 4 now says to check both directions): confirming the new version works
+answers half the question. It catches regressions but is blind to the mirror case — a bump
+that's actually a load-bearing fix — because "safe, nothing to fix" and "safe, and here's
+what it silently fixed" look identical from the forward-only check alone. Whenever you're
+about to spend effort empirically verifying a version (because coverage is absent and
+changelog-reading alone can't settle it), that same effort spent on the *old* version too is
+usually cheap relative to what it can reveal, and skipping it means half of what an empirical
+check could tell you never gets asked.


### PR DESCRIPTION
While going through the Dependabot backlog on my fork (#9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20) I ended up building a Claude Code skill to do it properly instead of just trusting "CI is green" — pulls the real changelog across the full version range, maps it to actual usage in the codebase, checks whether existing tests would really catch a regression, and verifies dependency behavior in both directions (old vs. new) rather than only confirming the new version works. Figured it's worth offering upstream rather than keeping it fork-local.

**What it actually found**, running it against all 12 open Dependabot PRs:
- Two real bugs "CI is green" was masking: akshare's TX-fallback schema drift (fixed in #250) and two live mypy type issues plus 17 stale `# type: ignore` suppressions (fixed in Pirat83/pybroker#24, mirrored here as #252).
- Two bumps that looked cosmetic but weren't: nbsphinx #19 is the fix for a currently-broken doc build (old version crashes against current Sphinx — verified by actually building the docs with both versions), and matplotlib #15 fixes a deprecation warning that's headed toward a hard crash on a future numpy release. Both confirmed by execution, not changelog-reading.
- The other 8 (#9, #10, #11, #12, #14, #17, #20, plus scikit-learn #13) came back genuinely safe, each with a comment posted on its own PR showing what was actually verified.

**What this PR adds:** just `.claude/skills/dependency-migration-triage/` — a markdown instructions file plus a reference doc of worked case studies. It's inert by default; nothing runs automatically, no CI/build behavior changes from merging it. It only does anything when explicitly invoked in a Claude Code session.

**Does it use Claude Code's multi-agent stuff?** No — the skill itself is a single self-contained workflow, no internal agent fan-out. Running it against all 12 PRs in parallel was orchestration I did on my end (spawning one Claude Code instance per PR), not something the skill requires. A single Claude Code session (interactive, or headless via [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) in CI) can run it standalone, one PR at a time.

Take it, adapt it, or ignore it — your call. If it'd be useful wired up to run automatically, it'd also work as the prompt behind a `claude-code-action` GitHub Actions workflow triggered on Dependabot PRs, rather than needing someone to invoke it by hand each time — happy to put that together too if you want it, or to keep contributing more from what I've been building on this fork in general.

---

**Evidence — every actual comment/PR it produced**, so this isn't just a claim:

- Fix PRs: [Pirat83/pybroker#250 / edtechre/pybroker#250](https://github.com/edtechre/pybroker/pull/250) (akshare), [Pirat83/pybroker#24](https://github.com/Pirat83/pybroker/pull/24) mirrored as [edtechre/pybroker#252](https://github.com/edtechre/pybroker/pull/252) (mypy)
- Pirat83/pybroker#9 (gh-action-pypi-publish): https://github.com/Pirat83/pybroker/pull/9#issuecomment-5079357135
- Pirat83/pybroker#10 (download-artifact): https://github.com/Pirat83/pybroker/pull/10#issuecomment-5079349501
- Pirat83/pybroker#11 (upload-artifact): https://github.com/Pirat83/pybroker/pull/11#issuecomment-5079355459
- Pirat83/pybroker#12 (setup-python): https://github.com/Pirat83/pybroker/pull/12#issuecomment-5079355809
- Pirat83/pybroker#13 (scikit-learn): https://github.com/Pirat83/pybroker/pull/13#issuecomment-5079251337
- Pirat83/pybroker#14 (sphinx-intl): https://github.com/Pirat83/pybroker/pull/14#issuecomment-5079358729
- Pirat83/pybroker#15 (matplotlib): https://github.com/Pirat83/pybroker/pull/15#issuecomment-5079373688
- Pirat83/pybroker#16 (mypy bump itself): https://github.com/Pirat83/pybroker/pull/16#issuecomment-5079293743
- Pirat83/pybroker#17 (ruff): https://github.com/Pirat83/pybroker/pull/17#issuecomment-5079360170
- Pirat83/pybroker#19 (nbsphinx): https://github.com/Pirat83/pybroker/pull/19#issuecomment-5079373780
- Pirat83/pybroker#20 (jupyter): https://github.com/Pirat83/pybroker/pull/20#issuecomment-5079354519