### PR TITLE
fix: enable mypy --warn-unused-ignores and remove stale ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ deps =
     numpy>=2.0.0
     mypy==2.3.0
 commands =
-    mypy --show-error-codes --ignore-missing-imports {posargs:src}
+    mypy --show-error-codes --ignore-missing-imports --warn-unused-ignores {posargs:src}
 
 [testenv:format]
 skip_install = True

--- a/src/pybroker/common.py
+++ b/src/pybroker/common.py
@@ -271,9 +271,9 @@ def to_datetime(
 ) -> datetime:
     """Converts ``date`` to :class:`datetime`."""
     if isinstance(date, pd.Timestamp):
-        return date.to_pydatetime()  # type: ignore[union-attr]
+        return date.to_pydatetime()
     elif isinstance(date, datetime):
-        return date  # type: ignore[return-value]
+        return date
     elif isinstance(date, str):
         return pd.to_datetime(date).to_pydatetime()
     elif isinstance(date, np.datetime64):

--- a/src/pybroker/context.py
+++ b/src/pybroker/context.py
@@ -699,7 +699,7 @@ class ExecContext(BaseContext):
         """Current bar's date expressed as a ``numpy.datetime64``."""
         self._verify_symbol()
         return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+            self.symbol,
             DataCol.DATE.value,
             self._sym_end_index[self.symbol],
         )
@@ -709,7 +709,7 @@ class ExecContext(BaseContext):
         """Current bar's open price."""
         self._verify_symbol()
         return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+            self.symbol,
             DataCol.OPEN.value,
             self._sym_end_index[self.symbol],
         )
@@ -719,7 +719,7 @@ class ExecContext(BaseContext):
         """Current bar's high price."""
         self._verify_symbol()
         return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+            self.symbol,
             DataCol.HIGH.value,
             self._sym_end_index[self.symbol],
         )
@@ -729,7 +729,7 @@ class ExecContext(BaseContext):
         """Current bar's low price."""
         self._verify_symbol()
         return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+            self.symbol,
             DataCol.LOW.value,
             self._sym_end_index[self.symbol],
         )
@@ -739,7 +739,7 @@ class ExecContext(BaseContext):
         """Current bar's close price."""
         self._verify_symbol()
         return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+            self.symbol,
             DataCol.CLOSE.value,
             self._sym_end_index[self.symbol],
         )
@@ -748,8 +748,8 @@ class ExecContext(BaseContext):
     def volume(self) -> Optional[NDArray[np.float64]]:
         """Current bar's volume."""
         self._verify_symbol()
-        return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+        return self._col_scope.fetch(
+            self.symbol,
             DataCol.VOLUME.value,
             self._sym_end_index[self.symbol],
         )
@@ -758,8 +758,8 @@ class ExecContext(BaseContext):
     def vwap(self) -> Optional[NDArray[np.float64]]:
         """Current bar's volume-weighted average price (VWAP)."""
         self._verify_symbol()
-        return self._col_scope.fetch(  # type: ignore[return-value]
-            self.symbol,  # type: ignore[arg-type]
+        return self._col_scope.fetch(
+            self.symbol,
             DataCol.VWAP.value,
             self._sym_end_index[self.symbol],
         )

--- a/src/pybroker/data.py
+++ b/src/pybroker/data.py
@@ -467,7 +467,7 @@ class AlpacaCrypto(DataSource):
             timeframe=TimeFrame(amount, unit),
             limit=None,
         )
-        df = _get_alpaca_crypto_bars(self._api, request).df  # type: ignore[union-attr]
+        df = _get_alpaca_crypto_bars(self._api, request).df
         if df.columns.empty:
             return pd.DataFrame(columns=self.COLUMNS)
         if df.empty:

--- a/src/pybroker/eval.py
+++ b/src/pybroker/eval.py
@@ -222,7 +222,7 @@ def conf_profit_factor(
     x: NDArray[np.float64], n: int, n_boot: int
 ) -> BootConfIntervals:
     """Computes confidence intervals for :func:`.profit_factor`."""
-    intervals = bca_boot_conf(x, n, n_boot, log_profit_factor)  # type: ignore[arg-type]
+    intervals = bca_boot_conf(x, n, n_boot, log_profit_factor)
     return BootConfIntervals(
         low_2p5=np.exp(intervals.low_2p5),
         high_2p5=np.exp(intervals.high_2p5),
@@ -237,7 +237,7 @@ def conf_sharpe_ratio(
     x: NDArray[np.float64], n: int, n_boot: int, obs: Optional[int] = None
 ) -> BootConfIntervals:
     """Computes confidence intervals for :func:`.sharpe_ratio`."""
-    intervals = bca_boot_conf(x, n, n_boot, sharpe_ratio)  # type: ignore[arg-type]
+    intervals = bca_boot_conf(x, n, n_boot, sharpe_ratio)
     if obs is not None:
         factor = np.sqrt(obs)
         intervals = BootConfIntervals(

--- a/src/pybroker/model.py
+++ b/src/pybroker/model.py
@@ -369,7 +369,7 @@ class ModelsMixin:
             input_cols: Optional[tuple[str]] = None
             if isinstance(model_result, tuple):
                 model = model_result[0]
-                input_cols = tuple(model_result[1])  # type: ignore[assignment]
+                input_cols = tuple(model_result[1])
             else:
                 model = model_result
             models[model_sym] = TrainedModel(

--- a/src/pybroker/scope.py
+++ b/src/pybroker/scope.py
@@ -613,7 +613,10 @@ class PriceScope:
             or isinstance(price, np.floating)
             or isinstance(price, Decimal)
         ):
-            fill_price = price
+            # price_type is checked above via identity comparison (not
+            # isinstance) to exclude bool, so mypy can't narrow price's
+            # type from this branch on its own; narrow explicitly.
+            fill_price = cast(Union[int, float, np.floating, Decimal], price)
         elif callable(price):
             bar_data = self._col_scope.bar_data_from_data_columns(
                 symbol, self._sym_end_index[symbol]
@@ -628,7 +631,7 @@ class PriceScope:
             # wrapped via Decimal(str(x)). Must divide by 100.0 (integer
             # ratio), NOT multiply by 0.01 (binary float 0.01 re-introduces
             # the rounding artifact we just removed).
-            fp = float(fill_price)  # type: ignore[arg-type]
+            fp = float(fill_price)
             if fp >= 0.0:
                 fill_price = int(fp * 100.0 + 0.5) / 100.0
             else:

--- a/src/pybroker/strategy.py
+++ b/src/pybroker/strategy.py
@@ -769,9 +769,9 @@ class WalkforwardMixin:
             yield WalkforwardWindow(train_idx, test_idx)
         else:
             res = len(window_dates) - (lookahead - 1) * windows
-            window_length = res / windows  # type: ignore[assignment]
-            train_length = int(window_length * train_size)
-            test_length = int(window_length * (1 - train_size))
+            avg_window_length = res / windows
+            train_length = int(avg_window_length * train_size)
+            test_length = int(avg_window_length * (1 - train_size))
             if train_length < 0 or test_length < 0:
                 raise ValueError(error_msg)
             while True:
@@ -1347,8 +1347,8 @@ class Strategy(
         )
         return tuple(
             sorted(
-                (day.value if isinstance(day, Day) else Day[day.upper()].value)  # type: ignore[union-attr]
-                for day in set(days)  # type: ignore[arg-type]
+                (day.value if isinstance(day, Day) else Day[day.upper()].value)
+                for day in set(days)
             )
         )  # type: ignore[return-value]
 


### PR DESCRIPTION
Mirrors Pirat83/pybroker#24, produced by triaging your Dependabot PR (Pirat83/pybroker#16, "Update mypy requirement from >=0.982 to >=2.3.0") with the [dependency-migration-triage skill](https://github.com/edtechre/pybroker/pull/251).

**Verified about that bump itself:** its `requirements.txt` floor has zero effect on CI — `Type check` runs `tox -e typecheck`, which already pins `mypy==2.3.0` exactly in `setup.cfg`, independent of `requirements.txt` (no workflow references it). The bump is safe but a no-op for what CI installs.

**What this PR does instead** — a finding from investigating that bump, not the bump itself:

Running the exact mypy version CI pins (2.3.0) with `--warn-unused-ignores` — a flag `setup.cfg`'s typecheck env doesn't currently use — showed **17 of the repo's 32 `# type: ignore` comments are already dead** under the current pin, and 2 more were still legitimately needed, but only by accident of mypy's narrowing limits rather than a real behavioral concern:

- Added `--warn-unused-ignores` to `[testenv:typecheck]` so this class of drift (this repo has hit it twice already — mypy 2.0's ndarray narrowing, mypy 2.3's `@njit` return-type change) gets caught automatically going forward instead of silently accumulating.
- Removed the 17 confirmed-dead ignores across `common.py`, `context.py`, `data.py`, `eval.py`, `model.py`, `strategy.py`.
- Fixed the 2 still-needed ones with real typing fixes instead of leaving them suppressed:
  - `strategy.py` `walkforward_split`: an `else` branch computed `window_length = res / windows` (float), reusing the same name as an earlier `if` branch's `window_length = int(...)` (int) in the same function scope. Renamed to `avg_window_length` — pure rename, no behavior change.
  - `scope.py` `PriceScope.fetch`: a branch guarded by `price_type is float or price_type is int` (identity check, needed to exclude `bool`) can't be narrowed by mypy the way `isinstance` can, so `fill_price` picked up the full declared union instead of just the numeric members. Narrowed explicitly with `cast(...)` — no-op at runtime.

**Verified by executing:**
- `mypy --show-error-codes --ignore-missing-imports --warn-unused-ignores src` → clean (was 17 errors before).
- The exact CI command (no `--warn-unused-ignores`) → still clean, matching current CI.
- `ruff format --diff src` / `ruff check src` → clean.
- Full existing suite (3586 tests) → passed unchanged, confirming the two real fixes don't alter runtime behavior.

**Not verified empirically, inferred from reading the code:** that all 17 removed ignores are genuinely dead rather than masking something — rests on mypy's own diagnostic plus manual reading of each site.

No regression test added — both real fixes are typing-hygiene only with no behavior change (confirmed by the unchanged suite above).