### PR TITLE
ci: bump pypa/gh-action-pypi-publish from 1.5.0 to 1.14.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
           name: artifact
           path: ./dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Why

This repo doesn't have Dependabot configured (no `.github/dependabot.yml`), so it never got the PR that Dependabot would have opened for this action. This PR mirrors that bump by hand — it's the same change that was raised and triaged via `dependency-migration-triage` on the fork: [Pirat83/pybroker#26](https://github.com/Pirat83/pybroker/pull/26).

## What was verified (not just inferred from changelogs)

- **Single call site**: `.github/workflows/main.yml`, using `user`/`password` (API token) auth, not Trusted Publishing.
- **Input schema**: diffed `action.yml` between v1.5.0 and v1.14.2 directly — `user`/`password` input names are unchanged; none of the deprecated-alias renames (`repository_url`, `packages_dir`, `verify_metadata`, `skip_existing`, `print_hash`) touch inputs this workflow uses.
- **Attestations-by-default** (added v1.10.0, on by default since v1.11.0): confirmed via the action's current README that this only activates under Trusted Publishing/OIDC. Since this workflow authenticates with a token, it's never triggered — no `id-token: write` permission is needed.
- **Container-based invocation rewrite** (v1.12.0) had documented quirks (self-hosted runners lacking Python, SHA-pinning breakage, nested composite actions, GitHub Enterprise). None apply here: hosted `ubuntu-latest` runner, tag-pinned (not SHA), single top-level call, github.com.
- **Legacy `.zip` sdist detection bug** (early attestations releases) doesn't apply — this repo only builds `--sdist`, producing a standard `.tar.gz`.

## Bonus: a real security fix this repo's config is exposed to

[GHSA-vxmw-7h4f-hqxh](https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh) (low-severity template-injection via `github.ref_name`, fixed in v1.13.0). The advisory calls out `pull_request`/`release`/`push: tags` triggers as the safe configurations — this workflow's `on: push` is unfiltered (tag-filtering happens inside the job's `if:`), so it's not in that safe bucket. Low impact in practice, but this bump is a genuine fix for this exact trigger shape, not just routine churn.

## Not done here (flagging, not implementing)

The action's maintainer has recommended migrating to Trusted Publishing (OIDC) over the long-lived `PYPI_API_TOKEN` since 2023. Adopting it requires configuring a trusted publisher on the PyPI project itself (outside this repo), so it's left as a judgment call for whoever owns that PyPI project, not bundled into this mechanical version bump.

No test coverage exists for the publish step (it only runs on tag pushes and can't reasonably be unit-tested without a real PyPI upload) — that's inherent to this call site, not something introduced by this change.