### PR TITLE
ci: bump actions/checkout from 4 to 7

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -24,7 +24,7 @@ jobs:
           - version: "3.12"
           - version: "3.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: asv continuous
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -24,7 +24,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -40,7 +40,7 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -66,7 +66,7 @@ jobs:
           - version: "3.13"
             toxenv: "py313"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -83,7 +83,7 @@ jobs:
       name: Build source distribution
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
 
         - uses: actions/setup-python@v5
           with:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -25,7 +25,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -41,7 +41,7 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -67,7 +67,7 @@ jobs:
           - version: "3.13"
             toxenv: "py313"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -84,7 +84,7 @@ jobs:
       name: Build source distribution
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
 
         - uses: actions/setup-python@v5
           with:


### PR DESCRIPTION
## Why

This repo doesn't have Dependabot configured (no `.github/dependabot.yml`), so it never got the PR that Dependabot would have opened for this action. This mirrors the bump already raised and triaged via `dependency-migration-triage` on the fork: [Pirat83/pybroker#25](https://github.com/Pirat83/pybroker/pull/25).

## What was verified (not just inferred from changelogs)

12 call sites: `main.yml` (5), `schedule.yml` (5), `asv-nightly.yml` (1), `asv-pr.yml` (1, was already pinned to v6 here, ahead of the rest).

**The one real behavior change across v4→v7:** v7.0.0 blocks checking out fork-PR code by default for `pull_request_target` and `workflow_run` triggers (security hardening, flagged `[BREAKING]`, backported to v4.4.0/v5.1.0/v6.1.0 too — opt-out via `allow-unsafe-pr-checkout: true`). Checked every trigger in this repo's workflows: `main.yml`/`schedule.yml` use `push`/`schedule`, `asv-nightly.yml` uses `schedule`+`workflow_dispatch`, `asv-pr.yml` uses plain `pull_request` (not `_target`). **None** use `pull_request_target` or `workflow_run` — this change doesn't engage anywhere in this repo.

Other range items checked and ruled out: the Node 20→24 runtime bump (v5.0.0) and the credential-persistence-location change (v6-beta, moved from local git config to `$RUNNER_TEMP`, relevant to Docker-container-action scenarios on old self-hosted runners) — both transparent on GitHub-hosted `ubuntu-latest`, which is all this repo uses. The `setup-pybroker` composite action does plain pip installs, no Docker-container steps, no unusual credential reads.

**Live execution evidence, from the fork:** this exact bump already ran in CI on Pirat83/pybroker#25 — every job using `actions/checkout@v7` (Check formatting, Lint, Type check, all 3 Test matrix legs, Build source distribution, and the ASV continuous job covering the v6→v7 `asv-pr.yml` step) passed on real GitHub-hosted runners.

Nothing needed fixing, and nothing here is a judgment call — safe to merge as-is.