### PR TITLE
docs: repair tox docs env, fix all Sphinx warnings, add docs CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,22 @@ jobs:
       - name: Run mypy
         run: python -m tox -e typecheck
 
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tox
+        run: python -m pip install --no-cache-dir tox
+
+      - name: Run sphinx-build
+        run: tox -e docs
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -106,6 +122,7 @@ jobs:
       - format
       - lint
       - typecheck
+      - docs
       - test
       - build_source_dist
     runs-on: ubuntu-latest

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -53,6 +53,22 @@ jobs:
       - name: Run mypy
         run: python -m tox -e typecheck
 
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tox
+        run: python -m pip install --no-cache-dir tox
+
+      - name: Run sphinx-build
+        run: tox -e docs
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,12 @@ import sys
 sys.path.insert(0, os.path.abspath("../../src/"))
 sys.path.insert(0, os.path.abspath("notebooks/"))
 
-nitpick_ignore = [("py:class", "type")]
+nitpick_ignore = [
+    ("py:class", "type"),
+    ("py:class", "numpy.float64"),
+    ("py:class", "numpy.int64"),
+    ("py:class", "numpy._typing._array_like._ScalarT"),
+]
 
 project = "PyBroker"
 copyright = "2026, Edward West"
@@ -18,7 +23,6 @@ extensions = [
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx.ext.autodoc",
-    "sphinx.ext.autodoc.typehints",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
@@ -44,6 +48,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "diskcache": ("https://grantjenks.com/docs/diskcache/", None),
+    "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -208,13 +208,14 @@ on quantitative finance and algorithmic trading:
       :maxdepth: 1
       :caption: Other Information
 
+      Benchmarking <benchmarking>
       Changelog <changelog>
       License <license>
 
 Contact
 =======
 
-.. image:: _static/email-image.png
+.. image:: ../_static/email-image.png
 
 .. toctree::
    :caption: Stock News & Alerts

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -2,4 +2,5 @@
 License
 #######
 
-.. include:: ../../LICENSE
+.. literalinclude:: ../../LICENSE
+   :language: text

--- a/docs/source/reference/pybroker.common.rst
+++ b/docs/source/reference/pybroker.common.rst
@@ -6,4 +6,8 @@ pybroker.common module
    :undoc-members:
    :show-inheritance:
    :exclude-members: ind_name, symbol, model_name, instance, name, exec_id,
-      predict_fn, shares, fill_price, order_type
+      predict_fn, shares, fill_price, order_type, input_cols, AVERAGE, BAR,
+      BUY_TO_CLOSE, BUY_TO_OPEN, CLOSE, DEFAULT, HIGH, LIMIT, LONG_ONLY,
+      LOSS, LOW, MARKET, MIDDLE, OPEN, ORDER_PERCENT, PER_ORDER, PER_SHARE,
+      PROFIT, SELL_TO_CLOSE, SELL_TO_OPEN, SHORT_ONLY, STOP_BAR, STOP_LOSS,
+      STOP_PROFIT, STOP_TRAILING, TRAILING

--- a/docs/source/reference/pybroker.config.rst
+++ b/docs/source/reference/pybroker.config.rst
@@ -10,4 +10,4 @@ pybroker.config module
       fee_mode, fee_amount, enable_fractional_shares, exit_on_last_bar,
       exit_cover_fill_price, exit_sell_fill_price, bars_per_year,
       return_signals, round_test_result, round_fill_price, subtract_fees,
-      return_stops
+      return_stops, position_mode

--- a/docs/source/reference/pybroker.context.rst
+++ b/docs/source/reference/pybroker.context.rst
@@ -7,4 +7,5 @@ pybroker.context module
    :show-inheritance:
    :exclude-members: symbol, date, buy_fill_price, buy_shares, buy_limit_price,
       sell_fill_price, sell_shares, sell_limit_price, hold_bars, score,
-      session, id, shares, bar_data, type
+      session, id, shares, bar_data, type, cover, long_stops, short_stops,
+      pending_order_id

--- a/docs/source/reference/pybroker.data.rst
+++ b/docs/source/reference/pybroker.data.rst
@@ -5,3 +5,4 @@ pybroker.data module
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: ADJ_CLOSE

--- a/docs/source/reference/pybroker.eval.rst
+++ b/docs/source/reference/pybroker.eval.rst
@@ -17,4 +17,4 @@ pybroker.eval module
       loss_rate, total_pnl, total_return_pct, total_fees, losing_trades,
       winning_trades, drawdown, annual_return_pct, annual_std_error,
       annual_volatility_pct, calmar, largest_loss_pct, largest_win_pct,
-      sortino, unrealized_pnl
+      sortino, unrealized_pnl, max_drawdown_date

--- a/docs/source/reference/pybroker.model.rst
+++ b/docs/source/reference/pybroker.model.rst
@@ -5,3 +5,4 @@ pybroker.model module
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: input_cols

--- a/docs/source/reference/pybroker.portfolio.rst
+++ b/docs/source/reference/pybroker.portfolio.rst
@@ -9,5 +9,5 @@ pybroker.portfolio module
       limit_price, order_type, pnl, cash, equity, margin, market_value,
       unrealized_pnl, close, entries, long_shares, short_shares, bars,
       cumulative_pnl, entry_date, exit_date, return_pct, pnl_per_bar, fees,
-      agg_pnl, entry, exit, stops, stop, percent, points, pos_type, stop_type
-      curr_value, curr_bars, stop_id, exit_price
+      agg_pnl, entry, exit, stops, stop, percent, points, pos_type, stop_type,
+      curr_value, curr_bars, stop_id, exit_price, created, intent, mae, mfe

--- a/docs/source/reference/pybroker.strategy.rst
+++ b/docs/source/reference/pybroker.strategy.rst
@@ -8,4 +8,4 @@ pybroker.strategy module
    :exclude-members: fn, id, indicator_names, model_names, symbols, end_date,
       orders, portfolio_bars, position_bars, start_date, test_data, train_data,
       bootstrap, metrics, metrics_df, portfolio, positions, trades, signals,
-      stops
+      stops, args, kwargs

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,17 +81,9 @@ commands =
 
 [testenv:docs]
 deps =
-    nbsphinx
-    sphinx
+    -r requirements.txt
 commands =
-    sphinx-apidoc \
-        --force \
-        --implicit-namespaces \
-        --module-first \
-        --separate \
-        -o docs/reference/ \
-        src/pybroker/
-    sphinx-build -n -W --keep-going -b html docs/ docs/_build/
+    sphinx-build -n -W --keep-going -b html docs/source/ docs/_build/
 
 [tool:pytest]
 testpaths = tests

--- a/src/pybroker/common.py
+++ b/src/pybroker/common.py
@@ -269,7 +269,7 @@ class BarData:
 def to_datetime(
     date: Union[str, datetime, np.datetime64, pd.Timestamp],
 ) -> datetime:
-    """Converts ``date`` to :class:`datetime`."""
+    """Converts ``date`` to :class:`datetime.datetime`."""
     if isinstance(date, pd.Timestamp):
         return date.to_pydatetime()
     elif isinstance(date, datetime):
@@ -283,7 +283,7 @@ def to_datetime(
 
 
 def to_decimal(value: Union[int, float, Decimal]) -> Decimal:
-    """Converts ``value`` to :class:`Decimal`."""
+    """Converts ``value`` to :class:`decimal.Decimal`."""
     value_type = type(value)
     if value_type == Decimal:
         return value  # type: ignore[return-value]

--- a/src/pybroker/context.py
+++ b/src/pybroker/context.py
@@ -269,7 +269,7 @@ class BaseContext:
 
         Args:
             name: Name used to identify the model that was registered with
-                :meth:`pybroker.model.model`.
+                :func:`pybroker.model.model`.
             symbol: Ticker symbol of the data that was used to train the model.
 
         Returns:
@@ -414,7 +414,8 @@ class ExecSignal(NamedTuple):
 
 class PosSizeContext(BaseContext):
     r"""Holds data for a position size handler set with
-    :meth:`pybroker.Strategy.set_pos_size_handler`. Used to set position sizes
+    :meth:`pybroker.strategy.Strategy.set_pos_size_handler`. Used to set
+    position sizes
     when placing orders from buy and sell signals.
 
     Attributes:
@@ -882,7 +883,7 @@ class ExecContext(BaseContext):
 
         Args:
             name: Name used to identify the model that was registered with
-                :meth:`pybroker.model.model`.
+                :func:`pybroker.model.model`.
             symbol: Ticker symbol of the data that was used to train the model.
                 If ``None``, the ``ExecContext``\ 's :attr:`.symbol` is used.
 

--- a/src/pybroker/data.py
+++ b/src/pybroker/data.py
@@ -257,6 +257,7 @@ class DataSource(ABC, DataSourceCacheMixin):
         adjust: Optional[Any],
     ) -> pd.DataFrame:
         """:meta public:
+
         Override this method to return data from a custom
         source. The returned :class:`pandas.DataFrame` must contain the
         following columns: ``symbol``, ``date``, ``open``, ``high``, ``low``,

--- a/src/pybroker/eval.py
+++ b/src/pybroker/eval.py
@@ -221,7 +221,7 @@ def sortino_ratio(
 def conf_profit_factor(
     x: NDArray[np.float64], n: int, n_boot: int
 ) -> BootConfIntervals:
-    """Computes confidence intervals for :func:`.profit_factor`."""
+    """Computes confidence intervals for ``profit_factor``."""
     intervals = bca_boot_conf(x, n, n_boot, log_profit_factor)
     return BootConfIntervals(
         low_2p5=np.exp(intervals.low_2p5),

--- a/src/pybroker/model.py
+++ b/src/pybroker/model.py
@@ -42,11 +42,11 @@ class ModelSource:
         indicator_names: :class:`Iterable` of names of
             :class:`pybroker.indicator.Indicator`\ s used as features of the
             model.
-        input_data_fn: :class:`Callable[[DataFrame], DataFrame]` for
+        input_data_fn: ``Callable[[DataFrame], DataFrame]`` for
             preprocessing input data passed to the model when making
             predictions. If set, ``input_data_fn`` will be called with a
             :class:`pandas.DataFrame` containing all test data.
-        predict_fn: :class:`Callable[[Model, DataFrame], ndarray]` that
+        predict_fn: ``Callable[[Model, DataFrame], ndarray]`` that
             overrides calling the model's default ``predict`` function. If set,
             ``predict_fn`` will be called with the trained model and a
             :class:`pandas.DataFrame` containing all test data.
@@ -100,11 +100,11 @@ class ModelLoader(ModelSource):
         indicator_names: :class:`Iterable` of names of
             :class:`pybroker.indicator.Indicator`\ s used as features of the
             model.
-        input_data_fn: :class:`Callable[[DataFrame], DataFrame]` for
+        input_data_fn: ``Callable[[DataFrame], DataFrame]`` for
             preprocessing input data passed to the model when making
             predictions. If set, ``input_data_fn`` will be called with a
             :class:`pandas.DataFrame` containing all test data.
-        predict_fn: :class:`Callable[[Model, DataFrame], ndarray]` that
+        predict_fn: ``Callable[[Model, DataFrame], ndarray]`` that
             overrides calling the model's default ``predict`` function. If set,
             ``predict_fn`` will be called with the trained model and a
             :class:`pandas.DataFrame` containing all test data.
@@ -161,11 +161,11 @@ class ModelTrainer(ModelSource):
         indicator_names: :class:`Iterable` of names of
             :class:`pybroker.indicator.Indicator`\ s used as features of the
             model.
-        input_data_fn: :class:`Callable[[DataFrame], DataFrame]` for
+        input_data_fn: ``Callable[[DataFrame], DataFrame]`` for
             preprocessing input data passed to the model when making
             predictions. If set, ``input_data_fn`` will be called with a
             :class:`pandas.DataFrame` containing all test data.
-        predict_fn: :class:`Callable[[Model, DataFrame], ndarray]` that
+        predict_fn: ``Callable[[Model, DataFrame], ndarray]`` that
             overrides calling the model's default ``predict`` function. If set,
             ``predict_fn`` will be called with the trained model and a
             :class:`pandas.DataFrame` containing all test data.
@@ -234,11 +234,11 @@ def model(
         indicators: :class:`Iterable` of
             :class:`pybroker.indicator.Indicator`\ s used as features of the
             model.
-        input_data_fn: :class:`Callable[[DataFrame], DataFrame]` for
+        input_data_fn: ``Callable[[DataFrame], DataFrame]`` for
             preprocessing input data passed to the model when making
             predictions. If set, ``input_data_fn`` will be called with a
             :class:`pandas.DataFrame` containing all test data.
-        predict_fn: :class:`Callable[[Model, DataFrame], ndarray]` that
+        predict_fn: ``Callable[[Model, DataFrame], ndarray]`` that
             overrides calling the model's default ``predict`` function. If set,
             ``predict_fn`` will be called with the trained model and a
             :class:`pandas.DataFrame` containing all test data.
@@ -281,16 +281,14 @@ def model(
 
 
 class CachedModel(NamedTuple):
-    """Stores cached model data.
-
-    Attributes:
-        model: Trained model instance.
-        input_cols: Names of the columns to be used as input for the model when
-            making predictions.
-    """
+    """Stores cached model data."""
 
     model: Any
+    """Trained model instance."""
+
     input_cols: Optional[tuple[str]]
+    """Names of the columns to be used as input for the model when making
+    predictions."""
 
 
 class ModelsMixin:

--- a/src/pybroker/strategy.py
+++ b/src/pybroker/strategy.py
@@ -1033,24 +1033,24 @@ class Strategy(
     def set_before_exec(
         self, fn: Optional[Callable[[Mapping[str, ExecContext]], None]]
     ):
-        r""":class:`Callable[[Mapping[str, ExecContext]]` that runs before all
-        execution functions.
+        r"""``Callable[[Mapping[str, ExecContext]], None]`` that runs before
+        all execution functions.
 
         Args:
             fn: :class:`Callable` that takes a :class:`Mapping` of all ticker
-                symbols to :class:`ExecContext`\ s.
+                symbols to :class:`~pybroker.context.ExecContext`\ s.
         """
         self._before_exec_fn = fn
 
     def set_after_exec(
         self, fn: Optional[Callable[[Mapping[str, ExecContext]], None]]
     ):
-        r""":class:`Callable[[Mapping[str, ExecContext]]` that runs after all
-        execution functions.
+        r"""``Callable[[Mapping[str, ExecContext]], None]`` that runs after
+        all execution functions.
 
         Args:
             fn: :class:`Callable` that takes a :class:`Mapping` of all ticker
-                symbols to :class:`ExecContext`\ s.
+                symbols to :class:`~pybroker.context.ExecContext`\ s.
         """
         self._after_exec_fn = fn
 
@@ -1094,10 +1094,10 @@ class Strategy(
         Args:
             start_date: Starting date of the backtest (inclusive). Must be
                 within ``start_date`` and ``end_date`` range that was passed to
-                :meth:`.__init__`.
+                :class:`.Strategy`.
             end_date: Ending date of the backtest (inclusive). Must be
                 within ``start_date`` and ``end_date`` range that was passed to
-                :meth:`.__init__`.
+                :class:`.Strategy`.
             timeframe: Formatted string that specifies the timeframe
                 resolution of the backtesting data. The timeframe string
                 supports the following units:
@@ -1193,10 +1193,10 @@ class Strategy(
             windows: Number of walkforward time windows.
             start_date: Starting date of the Walkforward Analysis (inclusive).
                 Must be within ``start_date`` and ``end_date`` range that was
-                passed to :meth:`.__init__`.
+                passed to :class:`.Strategy`.
             end_date: Ending date of the Walkforward Analysis (inclusive). Must
                 be within ``start_date`` and ``end_date`` range that was passed
-                to :meth:`.__init__`.
+                to :class:`.Strategy`.
             timeframe: Formatted string that specifies the timeframe
                 resolution of the backtesting data. The timeframe string
                 supports the following units:


### PR DESCRIPTION
## Why

Found while triaging [Pirat83/pybroker#23](https://github.com/Pirat83/pybroker/pull/23) (the `sphinx_rtd_theme` bump — see companion PR #256): `[testenv:docs]` in `setup.cfg` has never actually worked.

It points `sphinx-apidoc` at `docs/reference/` and `sphinx-build` at `docs/`, but `conf.py` and the committed `reference/` both live in `docs/source/` — the build dies immediately with "config directory doesn't contain a conf.py". It's also missing `sphinx_rtd_theme`/`ipython` from `deps`. No workflow has ever called `tox -e docs`, so this has been silently broken with the docs build completely unguarded — any change that breaks the Read the Docs build lands undetected. RTD itself (`.readthedocs.yml`) never runs apidoc; it builds `docs/source/conf.py` directly against the committed `reference/*.rst`.

Also folds in the one-line `sphinx.ext.autodoc.typehints` removal from #256, standalone — see that PR for why it's a pre-existing latent bug independent of the theme bump. Having it in both PRs means this CI job is green immediately regardless of which PR merges first.

## Changes

- **`setup.cfg`** — drop the `sphinx-apidoc` step. The committed `reference/*.rst` files are hand-tuned (e.g. `:exclude-members:` lines suppressing specific duplicate-object warnings) and `--force` silently clobbered them — that's what inflated warnings from 232 to 460 whenever the env was run manually. Fix the sourcedir to `docs/source/`. Install from `requirements.txt` so tox installs exactly what RTD installs.
- **`conf.py`** — drop the dead `autodoc.typehints` extension; `nitpick_ignore` numpy scalar types that aren't in numpy's own intersphinx inventory even though the mapping is wired up; add `joblib` to `intersphinx_mapping` (was missing entirely).
- **`reference/*.rst`** — extend `:exclude-members:` for names duplicated between each submodule's own page and the top-level `pybroker` page (re-exported classes' members getting documented twice). Along the way, fixed a pre-existing bug in `pybroker.portfolio.rst`: a missing comma had merged `stop_type` and `curr_value` into one broken RST field-list token, so neither was actually being excluded despite appearing in the list.
- **`src/pybroker/*.py`** — fixed docstring cross-references that were never going to resolve: composite `Callable[[...]]` type expressions wrapped in `:class:` roles (not resolvable targets, now plain code text), unqualified `datetime`/`Decimal` (need stdlib-qualified names to hit the intersphinx mapping), a `:meth:` role on a bare module-level function in `pybroker.model`, four `:meth:`.__init__`` refs to `Strategy`'s constructor (never autodoc-exposed — `special-members` only lists `__call__`), and a `CachedModel` `NamedTuple` documenting its fields twice (once via a napoleon `Attributes:` block, once via autodoc's own attribute scan) — moved to per-field docstrings, the pattern already used elsewhere in this file.
- **`license.rst`** — switched `.. include::` to `.. literalinclude::` so RST stops trying to structurally parse the LICENSE file's prose as nested block quotes. `LICENSE`'s own text is untouched.
- **`main.yml` / `schedule.yml`** — add a `docs` job (`tox -e docs`) mirroring the existing `format`/`lint`/`typecheck` jobs; `main.yml`'s `publish` job now also depends on it.

## What was verified by executing something (not inferred)

- `tox -e docs` from a clean checkout, full `requirements.txt` install (not a curated subset) — **build succeeded, exit 0, zero warnings**.
- Re-verified against both Sphinx 7.4.7 and Sphinx 9.1.0 directly — zero warnings both ways.
- `git status` after the build confirms `reference/*.rst` is untouched by the build itself (apidoc removal did its job).
- Spot-checked rendered HTML: de-duplicated members (e.g. `FeeMode.ORDER_PERCENT`) still appear on the top-level page they were consolidated onto — warnings were silenced by fixing the duplication, not by dropping documentation.