### PR TITLE
deps: bump diskcache requirement to >=5.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 akshare>=1.17.50
 alpaca-py>=0.10.0
-diskcache>=5.4.0
+diskcache>=5.6.3
 flake8>=5.0.4
 flake8-bugbear>=22.10.25
 joblib>=1.2.0


### PR DESCRIPTION
## Why

Mirrors [Pirat83/pybroker#22](https://github.com/Pirat83/pybroker/pull/22) (this repo has no Dependabot configured, so it never reached here on its own).

## What was verified

Real runtime dependency (`setup.cfg` `install_requires: diskcache>=5.4.0,<6` — this bump stays within that ceiling). Two call sites, both importing only `diskcache.Cache`: `src/pybroker/cache.py` (subclassed as `_L1Cache`, overriding `__init__`/`get`/`set`/`clear` to front the disk cache with an in-process LRU) and `src/pybroker/scope.py`. Nothing else from the package is used anywhere.

Diffed `diskcache/core.py` directly between v5.4.0 and v5.6.3 (no CHANGES/release-notes file exists upstream) — only cosmetic changes plus one strictly more permissive addition to `Cache.__init__` (coerces non-str `directory` args to `str`, doesn't affect this repo which already always passes a plain `str`). No change at all to `get`/`set`/`clear` — the three methods `_L1Cache` overrides.

**Coverage — actually executed.** `tests/test_cache.py` has three tests targeting `_L1Cache` specifically, exercising real reads/writes against a real disk-backed `Cache` (mocking is used only inside assertion blocks to prove the in-process LRU short-circuits disk reads, not to replace the underlying I/O). Ran all 29 tests in that file against both `diskcache==5.4.0` and `diskcache==5.6.3` in isolated venvs — 29/29 pass on both.

Nothing needed fixing.