### PR TITLE
deps: bump yfinance requirement to >=1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ Sphinx>=5.3.0
 sphinx_rtd_theme>=3.1.0
 sphinx-intl>=2.1.0
 yahooquery>=2.3.7
-yfinance>=0.2.55
+yfinance>=1.5.2


### PR DESCRIPTION
Mirrors the dependency-migration triage from
[Pirat83/pybroker#21](https://github.com/Pirat83/pybroker/pull/21) (a Dependabot PR — this
repo has no Dependabot configured, so bumps like this never land here otherwise). Full triage
writeup: https://github.com/Pirat83/pybroker/pull/21#issuecomment-5157002035

`yfinance` is a runtime dependency with a single call site: `yfinance.download()` in
`YFinance._fetch_data` (`src/pybroker/data.py:541`). This is a large jump (0.2.55 → 1.5.2,
crossing the 1.0 line), so it got full scrutiny.

**Verified by executing** (not just inferred): the existing `TestYFinance` suite in
`tests/test_data.py` mocks `yfinance.download()` completely with a static pickled fixture, so
it can't detect a real behavioral change in the dependency. To close that gap, I installed
`yfinance==0.2.55` and `yfinance==1.5.2` in isolated venvs and ran real, live
`yfinance.download()` calls through pybroker's actual `YFinance.query()` wrapper against
both — single-symbol and multi-symbol requests, both `auto_adjust` settings, and an
invalid-ticker/empty-result case. Column structure, schema, and the `'Date'` column name
surviving `reset_index()` are identical in both versions. Also ran the existing (mocked)
`TestYFinance` suite against both installs: 16/16 pass on each.

**Inferred from changelogs**: read every entry in yfinance's `CHANGELOG.rst` between 0.2.56
and 1.5.2 (not just the 1.5.2 release notes). The 1.0 release states "no breaking changes,
but some deprecation warnings." One entry (1.4.1, "preserve Date/Datetime index name in
`yf.download()` output") looked like it could affect `data.py:566`/`581`'s hardcoded
`'Date'` column access — checked directly above and confirmed it doesn't change behavior on
pybroker's daily/no-interval code path.

**New transitive dependencies** in 1.5.2 vs 0.2.55: adds `curl-cffi`, `protobuf`,
`websockets`; drops `frozendict`. None collide with anything pinned in `requirements.txt` or
`setup.cfg`. `setup.cfg`'s existing ceiling (`yfinance<2,>=0.2.55`) already permits 1.5.2, so
no ceiling change is needed.

**No source change required** — this PR is the version bump only. Happy for this to get a
deep review or just be trusted and merged directly, whichever you prefer.
