### PR TITLE
ci(asv): repair the benchmark gate — it has been measuring nothing and flagging noise

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -42,6 +42,7 @@ jobs:
           PY_VERSION: ${{ matrix.python.version }}
         run: |
           asv run HEAD^! \
+            --python="${PY_VERSION}" \
             --machine "ci-ubuntu-latest-py${PY_VERSION}" \
             --show-stderr
 

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -41,10 +41,33 @@ jobs:
         env:
           PY_VERSION: ${{ matrix.python.version }}
         run: |
+          set -o pipefail
           asv run HEAD^! \
             --python="${PY_VERSION}" \
             --machine "ci-ubuntu-latest-py${PY_VERSION}" \
-            --show-stderr
+            --show-stderr 2>&1 | tee asv-run.log
+
+      # `asv run` exits 0 when it matches no interpreter, so a leg that
+      # benchmarks nothing reports success. That is how the 3.12 and 3.13 legs
+      # stayed green for weeks while only 3.11 did any work.
+      - name: Assert benchmarks actually ran
+        env:
+          PY_VERSION: ${{ matrix.python.version }}
+        run: |
+          # Match only "No environments selected". "No executable found for
+          # python X" is a warning the legs whose version differs from
+          # asv.conf.json's pin emit while still building an env from
+          # --python, so it is not on its own a failure.
+          if grep -q "No environments selected" asv-run.log; then
+            echo "::error::asv selected no environment for Python" \
+                 "${PY_VERSION}. Nothing was benchmarked."
+            exit 1
+          fi
+          if ! grep -qE "^\[[ 0-9]+\.[0-9]+%\]" asv-run.log; then
+            echo "::error::asv produced no benchmark results for Python" \
+                 "${PY_VERSION}."
+            exit 1
+          fi
 
       - name: Upload asv results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -138,7 +138,7 @@ jobs:
           {
             echo "## ASV continuous — ${BASE_REF} → PR HEAD"
             echo ""
-            echo "Exit code: $ASV_EXIT (non-zero indicates flagged regression at --factor ${GATE_FACTOR})"
+            echo "Exit code: $ASV_EXIT (1 = flagged regression at --factor ${GATE_FACTOR}; 2 = a benchmark raised, nothing compared)"
             echo ""
             echo "### Moved by ${REPORT_FACTOR}x or more"
             echo ""
@@ -161,7 +161,7 @@ jobs:
           {
             echo "## ASV continuous — benchmark diff"
             echo ""
-            echo "Exit code: \`$ASV_EXIT\` (non-zero = flagged regression at \`--factor ${GATE_FACTOR}\`)"
+            echo "Exit code: \`$ASV_EXIT\` (\`1\` = flagged regression at \`--factor ${GATE_FACTOR}\`; \`2\` = a benchmark raised, so nothing was compared)"
             echo ""
             echo "**Moved by ${REPORT_FACTOR}x or more** — reported, not blocking:"
             echo ""
@@ -178,7 +178,9 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
-            if [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
+            if [ "$ASV_EXIT" = "2" ]; then
+              echo "_A benchmark raised an exception, so nothing was compared. \`bench-override\` does not apply — it accepts a measured slowdown, not a benchmark that cannot run._"
+            elif [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
               echo "_Gate forced green by \`bench-override\` label._"
             else
               echo "_Blocking at \`--factor ${GATE_FACTOR}\`, reporting from \`--factor ${REPORT_FACTOR}\`: 1.1 sits below this runner's noise floor, where identical code has flagged sub-2ms microbenchmarks at up to 1.18. Override via the \`bench-override\` PR label. For the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
@@ -203,6 +205,23 @@ jobs:
           if [ "$ASV_EXIT" = "0" ]; then
             echo "No regression flagged at ${GATE_FACTOR}x."
             exit 0
+          fi
+          # asv distinguishes the two non-zero exits and the gate must too.
+          # `asv run` returns 2 when any benchmark raised, and `asv
+          # continuous` propagates that immediately -- before it compares
+          # anything -- so exit 2 means "a benchmark is broken", not "this PR
+          # is slower". Reporting it as a regression is the same conflation
+          # that made a config drift look like one.
+          #
+          # bench-override deliberately does not apply here: it exists to
+          # accept a measured slowdown, not to merge a benchmark that cannot
+          # run.
+          if [ "$ASV_EXIT" = "2" ]; then
+            echo "::error::asv exited 2 -- at least one benchmark raised an" \
+                 "exception, so nothing was compared. This is not a" \
+                 "regression; the benchmark itself is broken."
+            grep -nE "failed" asv-continuous.log | head -20
+            exit 1
           fi
           if [ "$OVERRIDE" = "true" ]; then
             echo "Regression flagged (exit $ASV_EXIT) but 'bench-override' label is set — forcing green."

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -42,9 +42,17 @@ jobs:
           # comparisons, only factor and the median result", which disables
           # significance testing and lets an I/O-bound microbenchmark whose
           # error bars overlap trip --factor on noise alone.
+          # --interleave-rounds alternates rounds between the two commits
+          # instead of running each commit's rounds in a block, so drift over
+          # the job (thermal, noisy neighbours, page cache) hits both sides
+          # equally rather than landing entirely on "after". Without it a
+          # shared runner's second half reads as a regression: observed twice
+          # here on branches with byte-identical src/ and benchmarks/, each
+          # time flagging a different sub-100us benchmark.
           asv continuous "origin/${BASE_REF}" HEAD \
             --machine ci-ubuntu-latest \
             --factor 1.1 \
+            --interleave-rounds \
             >asv-continuous.log 2>&1
           EXIT=$?
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -21,7 +21,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Must match asv.conf.json's `pythons`. The setup action defaults to
+      # 3.12; when that drifts from the pin, asv finds no matching
+      # interpreter, selects no environments, and exits non-zero -- which the
+      # gate below reports as a regression while having benchmarked nothing.
       - uses: ./.github/actions/setup-pybroker
+        with:
+          python-version: "3.11"
 
       - name: Configure asv machine identity
         run: asv machine --yes --machine ci-ubuntu-latest

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -38,15 +38,38 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set +e
+          # No --no-stats: it means "do not use result statistics in
+          # comparisons, only factor and the median result", which disables
+          # significance testing and lets an I/O-bound microbenchmark whose
+          # error bars overlap trip --factor on noise alone.
           asv continuous "origin/${BASE_REF}" HEAD \
             --machine ci-ubuntu-latest \
             --factor 1.1 \
-            --no-stats \
             >asv-continuous.log 2>&1
           EXIT=$?
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
           cat asv-continuous.log
           exit 0
+
+      # asv exits non-zero both for a flagged regression and for having found
+      # no interpreter to benchmark with, and the gate below cannot tell those
+      # apart -- a config drift therefore reads as a regression while nothing
+      # was measured. Fail here with the real reason instead.
+      - name: Assert benchmarks actually ran
+        run: |
+          # Match only "No environments selected". "No executable found for
+          # python X" is a warning asv also emits when it skips one unusable
+          # entry while still building an env from another, so it is not on
+          # its own a failure.
+          if grep -q "No environments selected" asv-continuous.log; then
+            echo "::error::asv selected no environment -- the interpreter does" \
+                 "not match asv.conf.json's 'pythons'. Nothing was benchmarked."
+            exit 1
+          fi
+          if ! grep -qE "^\[[ 0-9]+\.[0-9]+%\]" asv-continuous.log; then
+            echo "::error::asv produced no benchmark results."
+            exit 1
+          fi
 
       - name: Write diff to job summary
         env:

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -12,6 +12,31 @@ permissions:
   contents: read
   pull-requests: write
 
+# Two thresholds, declared once so the flags and the prose describing them
+# cannot drift apart.
+#
+# REPORT_FACTOR is what gets shown: every benchmark that moved by 10% or
+# more lands in the PR comment for a human to read.
+#
+# GATE_FACTOR is what blocks the PR, and it is deliberately looser, because
+# 1.1 is below this runner's noise floor. Measured on six `asv continuous`
+# runs whose `src/` and `benchmarks/` were byte-identical between base and
+# head -- so every flagged result was noise:
+#
+#   1.18  CacheDiskHit.time_cache_disk_get            (429us)
+#   1.17  StoreBuildKernels...from_frame(10, 504)     (1.39ms)
+#   1.11  ModelPrepKernels.time_indicator_values...   (60us)
+#   1.11  ModelTrainPrep.time_train_models_per_symbol (1.92ms)
+#
+# One in six runs flagged something at 1.1, and every false positive was a
+# sub-2ms microbenchmark; the walkforward macrobenchmarks (100ms and up)
+# never moved. 1.25 clears the observed noise with margin. Raise the
+# sampling (`--attribute rounds=N`) rather than this number if that stops
+# being true -- loosening it further trades away real coverage.
+env:
+  REPORT_FACTOR: "1.1"
+  GATE_FACTOR: "1.25"
+
 jobs:
   benchmark:
     name: asv continuous
@@ -45,13 +70,12 @@ jobs:
           # --interleave-rounds alternates rounds between the two commits
           # instead of running each commit's rounds in a block, so drift over
           # the job (thermal, noisy neighbours, page cache) hits both sides
-          # equally rather than landing entirely on "after". Without it a
-          # shared runner's second half reads as a regression: observed twice
-          # here on branches with byte-identical src/ and benchmarks/, each
-          # time flagging a different sub-100us benchmark.
+          # equally rather than landing entirely on "after". It reuses the
+          # existing rounds, so it costs no extra runtime. Neither flag is
+          # sufficient on its own -- see GATE_FACTOR above.
           asv continuous "origin/${BASE_REF}" HEAD \
             --machine ci-ubuntu-latest \
-            --factor 1.1 \
+            --factor "${GATE_FACTOR}" \
             --interleave-rounds \
             >asv-continuous.log 2>&1
           EXIT=$?
@@ -79,6 +103,33 @@ jobs:
             exit 1
           fi
 
+      # Reads the results the step above already stored -- no benchmark is
+      # re-run, so the reporting threshold costs nothing. Non-fatal: a
+      # missing table must not fail a PR that the gate passed.
+      - name: Compare at the reporting threshold
+        id: compare
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set +e
+          asv compare "origin/${BASE_REF}" HEAD \
+            --machine ci-ubuntu-latest \
+            --factor "${REPORT_FACTOR}" \
+            --only-changed \
+            >asv-compare.log 2>&1
+          RC=$?
+          if [ "$RC" -ne 0 ]; then
+            echo "" >>asv-compare.log
+            echo "(asv compare exited ${RC}; the table above may be" \
+                 "incomplete. The gate verdict is unaffected.)" \
+              >>asv-compare.log
+          elif [ ! -s asv-compare.log ]; then
+            echo "No benchmark moved by ${REPORT_FACTOR}x or more." \
+              >asv-compare.log
+          fi
+          cat asv-compare.log
+          exit 0
+
       - name: Write diff to job summary
         env:
           ASV_EXIT: ${{ steps.continuous.outputs.exit_code }}
@@ -87,7 +138,15 @@ jobs:
           {
             echo "## ASV continuous — ${BASE_REF} → PR HEAD"
             echo ""
-            echo "Exit code: $ASV_EXIT (non-zero indicates flagged regression at --factor 1.1)"
+            echo "Exit code: $ASV_EXIT (non-zero indicates flagged regression at --factor ${GATE_FACTOR})"
+            echo ""
+            echo "### Moved by ${REPORT_FACTOR}x or more"
+            echo ""
+            echo '```'
+            cat asv-compare.log
+            echo '```'
+            echo ""
+            echo "### Full run"
             echo ""
             echo '```'
             cat asv-continuous.log
@@ -102,10 +161,16 @@ jobs:
           {
             echo "## ASV continuous — benchmark diff"
             echo ""
-            echo "Exit code: \`$ASV_EXIT\` (non-zero = flagged regression at \`--factor 1.1\`)"
+            echo "Exit code: \`$ASV_EXIT\` (non-zero = flagged regression at \`--factor ${GATE_FACTOR}\`)"
+            echo ""
+            echo "**Moved by ${REPORT_FACTOR}x or more** — reported, not blocking:"
+            echo ""
+            echo '```'
+            cat asv-compare.log
+            echo '```'
             echo ""
             echo "<details>"
-            echo "<summary>Benchmark output</summary>"
+            echo "<summary>Full benchmark output</summary>"
             echo ""
             echo '```'
             cat asv-continuous.log
@@ -116,7 +181,7 @@ jobs:
             if [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
               echo "_Gate forced green by \`bench-override\` label._"
             else
-              echo "_Blocking at \`--factor 1.1\`; override via the \`bench-override\` PR label. Shared GitHub runners are noisy — for the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
+              echo "_Blocking at \`--factor ${GATE_FACTOR}\`, reporting from \`--factor ${REPORT_FACTOR}\`: 1.1 sits below this runner's noise floor, where identical code has flagged sub-2ms microbenchmarks at up to 1.18. Override via the \`bench-override\` PR label. For the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
             fi
           } > sticky-comment.md
 
@@ -136,7 +201,7 @@ jobs:
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'bench-override') }}
         run: |
           if [ "$ASV_EXIT" = "0" ]; then
-            echo "No regression flagged."
+            echo "No regression flagged at ${GATE_FACTOR}x."
             exit 0
           fi
           if [ "$OVERRIDE" = "true" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ tox -e py311,py312,py313  # full test matrix
 
 # Benchmarks (asv; see Performance & Benchmarks)
 asv run --quick             # fast feedback, one sample per benchmark
-asv continuous master HEAD  # what the CI PR gate runs (--factor 1.1)
+asv continuous master HEAD  # what the CI PR gate runs (blocks at --factor 1.25)
 
 # Docs — CI runs `tox -e docs` on Python 3.12; it is STRICT
 # (`sphinx-build -n -W --keep-going`), so any warning fails the build.
@@ -280,8 +280,10 @@ between runs on NumPy arrays and Numba kernels.
   against `master`). Process doc: `docs/source/benchmarking.rst`.
 - **Perf-sensitive change → run the relevant benches before and after:**
   `asv continuous master HEAD` (a targeted `--bench <pattern>` pass first
-  is fine). CI fails PRs on regressions > 1.1× unless the PR carries the
-  `bench-override` label. **New hot path → add a benchmark.**
+  is fine). CI blocks PRs on regressions > 1.25× unless the PR carries the
+  `bench-override` label, and reports everything > 1.1× without blocking —
+  1.1 sits below the shared runner's noise floor. **New hot path → add a
+  benchmark.**
 - `WalkforwardCold` intentionally includes Numba JIT compile time — it
   validates the `cache=True` contract. Never add warmup to it.
 - Ad-hoc JSON-baseline runners exist for targeted comparisons
@@ -433,7 +435,7 @@ done.
 7. If indicators, scopes, or context slicing were touched:
    `python -m pytest tests/test_vect.py -k look_ahead`
 8. If perf-sensitive: `asv continuous master HEAD` — no regression
-   > 1.1×.
+   > 1.25× (the blocking threshold); investigate anything > 1.1×.
 9. If the public API changed: export added in `__init__.py`, docstrings
    complete, `:exclude-members:` in `pybroker.strategy.rst` updated.
 10. If `skills/`, public signatures/docstrings in `src/`, or the doc

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -36,12 +36,22 @@ Compare two commits:
    asv continuous master HEAD   # local equivalent of the CI gate
    asv compare master HEAD      # diff table
 
-The PR gate adds ``--factor 1.1 --no-stats --machine ci-ubuntu-latest`` and
+The PR gate adds
+``--factor 1.1 --interleave-rounds --machine ci-ubuntu-latest`` and
 resolves the base as ``origin/<base branch>``:
 
 .. code-block:: bash
 
-   asv continuous origin/master HEAD --factor 1.1 --no-stats
+   asv continuous origin/master HEAD --factor 1.1 --interleave-rounds
+
+``--interleave-rounds`` alternates rounds between the two commits instead
+of running each commit's rounds in a block, so drift over the job
+(thermal throttling, noisy neighbours, page cache) hits both sides
+equally instead of landing entirely on whichever commit ran second. On a
+shared runner, omitting it makes microsecond-scale benchmarks read as
+regressions on branches with identical code. ``--no-stats`` is
+deliberately *not* used: it disables significance testing, comparing raw
+medians against ``--factor`` alone.
 
 Generate and preview the HTML dashboard:
 

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -36,22 +36,38 @@ Compare two commits:
    asv continuous master HEAD   # local equivalent of the CI gate
    asv compare master HEAD      # diff table
 
-The PR gate adds
-``--factor 1.1 --interleave-rounds --machine ci-ubuntu-latest`` and
-resolves the base as ``origin/<base branch>``:
+The PR gate uses two thresholds. It blocks at ``--factor 1.25`` and
+reports everything that moved by ``1.1`` or more, resolving the base as
+``origin/<base branch>``:
 
 .. code-block:: bash
 
-   asv continuous origin/master HEAD --factor 1.1 --interleave-rounds
+   asv continuous origin/master HEAD --factor 1.25 --interleave-rounds
+   asv compare origin/master HEAD --factor 1.1 --only-changed
 
+The second command re-reads the results the first one stored, so it costs
+no extra benchmarking.
+
+Why the gate is looser than the report: ``1.1`` is below a shared
+runner's noise floor. Across six ``asv continuous`` runs whose ``src/``
+and ``benchmarks/`` were byte-identical between base and head, one run
+still flagged a regression — always a sub-2ms microbenchmark, at ratios
+up to ``1.18``. The walkforward macrobenchmarks (100ms and up) never
+moved. Gating at ``1.25`` clears the measured noise; the ``1.1`` table
+keeps the smaller movements visible for a human to judge.
+
+Two flags do part of the work but are not sufficient alone.
 ``--interleave-rounds`` alternates rounds between the two commits instead
 of running each commit's rounds in a block, so drift over the job
 (thermal throttling, noisy neighbours, page cache) hits both sides
-equally instead of landing entirely on whichever commit ran second. On a
-shared runner, omitting it makes microsecond-scale benchmarks read as
-regressions on branches with identical code. ``--no-stats`` is
-deliberately *not* used: it disables significance testing, comparing raw
-medians against ``--factor`` alone.
+equally instead of landing entirely on whichever commit ran second; it
+reuses the existing rounds, so it is free. ``--no-stats`` is deliberately
+*not* used: it disables significance testing, comparing raw medians
+against ``--factor`` alone.
+
+If the noise floor rises, raise the sampling
+(``--attribute rounds=N``) rather than the gate factor — loosening the
+factor trades away real coverage.
 
 Generate and preview the HTML dashboard:
 
@@ -64,8 +80,9 @@ Benchmark Suite
 ---------------
 
 The asv suite lives in ``benchmarks/`` across four modules. CI fails PRs on
-regressions greater than 1.1x unless the PR carries the ``bench-override``
-label. New hot paths should add a benchmark.
+regressions greater than 1.25x unless the PR carries the ``bench-override``
+label, and reports anything above 1.1x without blocking. New hot paths
+should add a benchmark.
 
 - ``bench_backtest.py`` - end-to-end walkforward (warm, cold, scaled,
   models, intervals, slippage-free) plus microbenchmarks for the indicator


### PR DESCRIPTION
The asv gate has been red on every PR since `v2_preview` merged into `dev`, and it has been benchmarking nothing. Four defects, each verified by running the real workflows on a fork.

The common thread: `asv` exits non-zero for several unrelated reasons and the gate treated every one of them as "this PR is slower". Two of the four defects are that single mistake, seen from opposite ends.

## 1. The gate benchmarks nothing and reports it as a regression

`37848d6` changed `asv.conf.json`'s `pythons` from `3.12` to `3.11`, but `asv-pr.yml` passes no `python-version`, so it gets the setup action's `3.12` default. asv then reports:

```
· No executable found for python 3.11
· No environments selected
```

and exits 1 — which the regression gate reports as a flagged regression, having measured nothing. The job finishes in ~36 s instead of ~16 min. Pins the job to 3.11 to match the config.

`asv-nightly.yml` sets up each matrix Python but never passes `--python` to `asv run`, so every leg falls back to the config's 3.11. The 3.12 and 3.13 legs matched no environment, benchmarked nothing, and **still reported success** — so the nightly matrix has effectively been 3.11-only. Passes the matrix version through.

Verified: all three nightly legs now run the full suite to `[100.00%]` with identical benchmark sets.

## 2. Nothing asserts that benchmarks actually ran

Defect 1 was invisible for weeks precisely because `asv run` exits 0 when it selects no environment. Both workflows now assert that work happened, failing with the real reason instead of a phantom regression.

Verified against the actual broken run: it emits `No environments selected` and zero result lines, so the guard fires. A healthy run has hundreds of result lines and zero matches.

The check deliberately does **not** treat `No executable found for python X` as fatal — legs whose version differs from `asv.conf.json`'s pin emit that warning while still building an environment from `--python`, so matching on it would fail exactly the legs this PR repairs.

## 3. The gate flags noise as a regression

**`--factor 1.1` is below this runner's noise floor.** That is the finding, and it took six runs to establish it properly.

Two flags were wrong and are fixed. `--no-stats` is documented as *"do not use result statistics in comparisons, only `factor` and the median result"* — it disables significance testing entirely. Removed. And `asv continuous` runs each commit's rounds in a block, so drift over the job (thermal, noisy neighbours, page cache) lands entirely on whichever commit ran second; `--interleave-rounds` alternates them so drift hits both sides equally. It reuses the existing rounds, so it costs no extra runtime.

**Neither was sufficient.** I initially concluded interleaving had fixed it, on the strength of one clean run. It had not — the gate then flagged `1.17` and `1.11` on a commit in this very PR that touched only a `.rst` file.

Across six `asv continuous` runs whose `src/` and `benchmarks/` were **byte-identical** between base and head, one still flagged a regression. Every false positive was a sub-2ms microbenchmark, and a different one each time:

| ratio | benchmark | scale |
|---|---|---|
| 1.18 | `CacheDiskHit.time_cache_disk_get` | 429 µs |
| 1.17 | `StoreBuildKernels...from_frame(10, 504)` | 1.39 ms |
| 1.11 | `ModelPrepKernels.time_indicator_values_for_dates` | 60 µs |
| 1.11 | `ModelTrainPrep.time_train_models_per_symbol` | 1.92 ms |

The walkforward macrobenchmarks (100 ms and up) never moved. At roughly one false positive in six runs, `bench-override` becomes routine — which is worse than having no gate, because it trains reviewers to dismiss it.

The clearest demonstration came from running the gate on three Pythons at once, over one commit pair with identical `src/` and `benchmarks/`:

| leg | benchmark | before → after | ratio |
|---|---|---|---|
| 3.11 | `IndicatorKernels.time_cross(1000)` | 7.25 → 8.11 µs | **1.12** |
| 3.12 | `IndicatorKernels.time_cross(1000)` | 6.61 → 5.49 µs | **0.83** |
| 3.13 | `CacheL1Hit.time_cache_l1_get` | 2.19 → 1.90 µs | 0.87 |

The same benchmark reads 12 % slower on one leg and 17 % faster on another, in the same run. At `--factor 1.1` the 3.11 leg blocks; at 1.25 all three pass and the movements are still reported.

So the threshold is split in two:

- **`asv continuous --factor 1.25`** decides pass/fail, clearing the measured noise with margin.
- **`asv compare --factor 1.1 --only-changed`** then re-reads the results already stored and puts everything that moved into the comment. It runs no benchmarks and costs no wall clock, so nothing is hidden — smaller movements are reported for a human to judge rather than blocking.

Both numbers are declared once as workflow `env` vars so the flags and the prose describing them cannot drift apart. If the noise floor rises, the fix is more sampling (`--attribute rounds=N`), not a looser factor.

I'd rather show you the measurements than assert a number, so: happy to gate at 1.1 and accept the flake rate, or go report-only, if you'd prefer either.

## 4. A broken benchmark was reported as a regression

asv has two distinct non-zero exits and the gate collapsed them into one message. `asv run` returns 2 when a benchmark *raises* (`asv_runner` `run.py:607`), and `asv continuous` propagates that immediately — before it compares anything. The gate printed "Regression flagged (exit 2)" and pointed the author at a performance problem that does not exist.

Same conflation as defect 1, from the other direction. It surfaced the moment the gate started working: #286's `ModelTrainParallel` had a parallel leg that dies inside the loky worker, and the gate blamed it on performance.

Exit 2 now fails with the real reason and prints the failing rows. `bench-override` deliberately does not apply to it — that label exists to accept a measured slowdown, not to merge a benchmark that cannot run.

## Verification

- **asv-nightly** — all 3 legs green on a fork, full suite to `[100.00%]`, identical benchmark sets, guard step executed and passed in every leg.
- **asv-pr gate** — green on this PR with the two thresholds in place, guard step passed, and the `asv compare` step resolved the stored results and printed a real table (it is not silently degrading to its fallback: verified against asv's own `compare.py`, where a missing result raises `Did not find results for commit …` and exits non-zero, while empty output can only mean nothing crossed the threshold).
- **The measurements above** come from that same reporting step, which is how a 1.12 and a 0.83 on one benchmark in one run became visible at all.

## Merge order

These form a stack. Merging out of order works but makes the diffs harder to read, so:

**1. This PR (#287) first.** It is the bug fix and everything else depends on it — until it lands, no other PR gets a gate run that measures anything. Self-contained, targets `dev`, nothing else needs to move first.

**2. #286 second.** It currently carries this branch merged in, because for `pull_request` events GitHub takes the workflow from the merge ref — without the fix present in the branch, its gate no-ops in 36 s. Once this lands, I rebase #286 and those CI commits drop out on their own, leaving just the benchmark. Its gate is green and the benchmark measures a 1.83× `parallel_models` speedup.

**3. #288 third** — the single-source follow-up, stacked on this branch. Same reason: until this merges, its diff shows these commits too. After this lands I rebase it and the diff reduces to the source-of-truth change alone.

⚠️ **One thing to check when that third PR lands:** it turns the gate into a matrix, so the check name changes from `asv continuous` to `asv continuous (Python 3.11)` / `(3.12)` / `(3.13)`. If a branch protection rule requires the old name, it needs updating or the gate silently stops being required. I can't see those settings from here.

**4. Python 3.14 last**, as its own PR — one entry in the versions file plus `envlist`. Only worth taking if the full test matrix is green on it; it is deliberately separable so a dependency that isn't ready on 3.14 blocks nothing else.

Nothing here needs the `bench-override` label.

## Not included

Kept out of this PR so an urgent bug fix does not wait on a workflow refactor:

- **The matrix is still hand-synced across 18 literals.** `asv.conf.json`'s pin, the workflow matrices, `setup.cfg`'s `envlist` and the action's default are kept in step by hand — which is how this broke in the first place. A single source of truth consumed via `fromJSON`, plus a consistency check for the files that cannot read it, makes that class of drift a CI failure instead of a silent no-op.
- **Regressions on 3.12+ are caught by nothing.** This gate benchmarks one version; the nightly runs three but only uploads a 30-day artifact with no baseline or comparison, and `.asv/` is gitignored so no history accumulates. Widening `asv continuous` across the matrix fixes it with no storage infrastructure at all, since it benchmarks both commits in the same job. Related to the "historical dashboard" question left open in #231.

Both are in #288 — sent separately so they can be judged on their own, and so this one can land now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
