### PR TITLE
ci: single-source the Python matrix and gate benchmarks on every version

### DIFF
--- a/.github/actions/setup-pybroker/action.yml
+++ b/.github/actions/setup-pybroker/action.yml
@@ -3,12 +3,30 @@ description: Install Python, asv, and cached pip deps for pybroker benchmarks
 
 inputs:
   python-version:
-    description: Python version
-    default: "3.12"
+    description: >
+      Python version to benchmark on. Required and deliberately without a
+      default: a default is what silently diverged from asv.conf.json's
+      pin, leaving the gate benchmarking on an interpreter the config did
+      not list. Callers pass a version from .github/python-versions.json.
+    required: true
 
 runs:
   using: "composite"
   steps:
+    # GitHub does not enforce `required` for composite action inputs -- an
+    # omitted one arrives as the empty string, and setup-python would then
+    # fall back to whatever Python the runner image ships. Fail instead.
+    - name: Require an explicit Python version
+      shell: bash
+      env:
+        PY_VERSION: ${{ inputs.python-version }}
+      run: |
+        if [ -z "$PY_VERSION" ]; then
+          echo "::error::setup-pybroker requires an explicit" \
+               "python-version input; got an empty value."
+          exit 1
+        fi
+
     - name: Set up Python
       uses: actions/setup-python@v6
       id: setup-python

--- a/.github/python-versions.json
+++ b/.github/python-versions.json
@@ -1,0 +1,14 @@
+{
+  "//": [
+    "Single source of truth for the Python versions CI uses.",
+    "'versions' drives the test matrix, the asv PR gate and the asv nightly",
+    "matrix; 'tooling' is the one interpreter for format, lint, typecheck,",
+    "docs and the sdist build. Workflows read this file with fromJSON();",
+    "declaration sites that cannot (setup.cfg, asv.conf.json, pyproject.toml,",
+    ".readthedocs.yml) are held to it by",
+    ".github/scripts/check_python_versions.py, which CI runs on every push.",
+    "Adding a version is one entry here plus whatever that check reports."
+  ],
+  "versions": ["3.11", "3.12", "3.13"],
+  "tooling": "3.12"
+}

--- a/.github/scripts/check_python_versions.py
+++ b/.github/scripts/check_python_versions.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Assert every Python-version declaration agrees with the CI matrix.
+
+``.github/python-versions.json`` is the single source of truth. The
+workflows consume it directly with ``fromJSON()``; the files checked here
+cannot, so they are kept in step by hand -- which is exactly how the asv
+gate came to benchmark on an interpreter its own config did not list.
+This check turns that class of drift into a CI failure.
+
+Run locally from the repository root:
+
+    python .github/scripts/check_python_versions.py
+
+Exits 0 when every site agrees, 1 with one line per disagreement
+otherwise.
+"""
+
+import configparser
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SSOT = ROOT / ".github" / "python-versions.json"
+
+
+def toxenv(version: str) -> str:
+    """Derives a tox environment name (``3.11`` -> ``py311``)."""
+    return "py" + version.replace(".", "")
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    """Sorts version strings numerically, so 3.9 precedes 3.11."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def check_asv_conf(
+    versions: list[str], tooling: str, fail: list[str]
+) -> None:
+    """asv builds one environment per entry in ``pythons``."""
+    path = ROOT / "asv.conf.json"
+    pythons = json.loads(path.read_text())["pythons"]
+    if pythons != versions:
+        fail.append(
+            f"asv.conf.json: 'pythons' is {pythons}, expected {versions}. "
+            "The benchmark suite must declare every supported version so "
+            "the PR gate can select each one with --python."
+        )
+
+
+def check_setup_cfg(
+    versions: list[str], tooling: str, fail: list[str]
+) -> None:
+    """setup.cfg carries the tox envlist, the floor, and two pins."""
+    cfg = configparser.RawConfigParser()
+    cfg.read(ROOT / "setup.cfg")
+    floor = min(versions, key=version_key)
+
+    envlist = [
+        env.strip()
+        for env in cfg.get("tox:tox", "envlist").split(",")
+        if env.strip()
+    ]
+    expected_envlist = [toxenv(version) for version in versions]
+    if envlist != expected_envlist:
+        fail.append(
+            f"setup.cfg [tox:tox]: 'envlist' is {envlist}, expected "
+            f"{expected_envlist}."
+        )
+
+    python_requires = cfg.get("options", "python_requires").strip()
+    if python_requires != f">={floor}":
+        fail.append(
+            f"setup.cfg [options]: 'python_requires' is "
+            f"{python_requires!r}, expected '>={floor}' -- the lowest "
+            "version in the matrix."
+        )
+
+    mypy_version = cfg.get("mypy", "python_version").strip()
+    if mypy_version != floor:
+        fail.append(
+            f"setup.cfg [mypy]: 'python_version' is {mypy_version!r}, "
+            f"expected {floor!r} -- mypy must check against the oldest "
+            "supported version, not the newest."
+        )
+
+    basepython = cfg.get("testenv:typecheck", "basepython").strip()
+    if basepython != f"python{tooling}":
+        fail.append(
+            f"setup.cfg [testenv:typecheck]: 'basepython' is "
+            f"{basepython!r}, expected 'python{tooling}'."
+        )
+
+
+def check_readthedocs(
+    versions: list[str], tooling: str, fail: list[str]
+) -> None:
+    """Read the Docs pins its build interpreter under ``build.tools``.
+
+    Matched with a regex rather than parsed: PyYAML is not a dependency
+    of this check, and the pin is a single unambiguous line.
+    """
+    path = ROOT / ".readthedocs.yml"
+    matches = re.findall(
+        r'^\s+python:\s*"([^"]+)"\s*$', path.read_text(), re.MULTILINE
+    )
+    if len(matches) != 1:
+        fail.append(
+            f".readthedocs.yml: expected exactly one 'python: \"X.Y\"' "
+            f"line, found {len(matches)}."
+        )
+    elif matches[0] != tooling:
+        fail.append(
+            f".readthedocs.yml: build.tools.python is {matches[0]!r}, "
+            f"expected {tooling!r}."
+        )
+
+
+def check_pyproject(
+    versions: list[str], tooling: str, fail: list[str]
+) -> None:
+    """ruff's ``target-version`` selects the syntax level it assumes."""
+    path = ROOT / "pyproject.toml"
+    with path.open("rb") as handle:
+        target = tomllib.load(handle)["tool"]["ruff"]["target-version"]
+    supported = [toxenv(version) for version in versions]
+    if target not in supported:
+        fail.append(
+            f"pyproject.toml [tool.ruff]: 'target-version' is {target!r}, "
+            f"which is not one of the supported versions {supported}."
+        )
+
+
+def main() -> int:
+    ssot = json.loads(SSOT.read_text())
+    versions: list[str] = ssot["versions"]
+    tooling: str = ssot["tooling"]
+
+    fail: list[str] = []
+    if not versions:
+        fail.append(f"{SSOT.name}: 'versions' is empty.")
+    if versions != sorted(versions, key=version_key):
+        fail.append(
+            f"{SSOT.name}: 'versions' must be listed oldest first, so the "
+            "lowest entry is unambiguously the support floor."
+        )
+    if tooling not in versions:
+        fail.append(
+            f"{SSOT.name}: 'tooling' is {tooling!r}, which is not in "
+            f"'versions' {versions}. CI would run format, lint, typecheck "
+            "and docs on an untested interpreter."
+        )
+
+    if not fail:
+        check_asv_conf(versions, tooling, fail)
+        check_setup_cfg(versions, tooling, fail)
+        check_readthedocs(versions, tooling, fail)
+        check_pyproject(versions, tooling, fail)
+
+    if fail:
+        print(
+            f"Python version declarations disagree with {SSOT.name} "
+            f"(versions={versions}, tooling={tooling}):\n",
+            file=sys.stderr,
+        )
+        for message in fail:
+            print(f"  - {message}", file=sys.stderr)
+        print(
+            "\nUpdate the site above, or the source of truth if the "
+            "matrix itself changed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"All Python version declarations agree with {SSOT.name}: "
+        f"versions={versions}, tooling={tooling}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -42,6 +42,7 @@ jobs:
           PY_VERSION: ${{ matrix.python.version }}
         run: |
           asv run HEAD^! \
+            --python="${PY_VERSION}" \
             --machine "ci-ubuntu-latest-py${PY_VERSION}" \
             --show-stderr
 

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -41,10 +41,33 @@ jobs:
         env:
           PY_VERSION: ${{ matrix.python.version }}
         run: |
+          set -o pipefail
           asv run HEAD^! \
             --python="${PY_VERSION}" \
             --machine "ci-ubuntu-latest-py${PY_VERSION}" \
-            --show-stderr
+            --show-stderr 2>&1 | tee asv-run.log
+
+      # `asv run` exits 0 when it matches no interpreter, so a leg that
+      # benchmarks nothing reports success. That is how the 3.12 and 3.13 legs
+      # stayed green for weeks while only 3.11 did any work.
+      - name: Assert benchmarks actually ran
+        env:
+          PY_VERSION: ${{ matrix.python.version }}
+        run: |
+          # Match only "No environments selected". "No executable found for
+          # python X" is a warning the legs whose version differs from
+          # asv.conf.json's pin emit while still building an env from
+          # --python, so it is not on its own a failure.
+          if grep -q "No environments selected" asv-run.log; then
+            echo "::error::asv selected no environment for Python" \
+                 "${PY_VERSION}. Nothing was benchmarked."
+            exit 1
+          fi
+          if ! grep -qE "^\[[ 0-9]+\.[0-9]+%\]" asv-run.log; then
+            echo "::error::asv produced no benchmark results for Python" \
+                 "${PY_VERSION}."
+            exit 1
+          fi
 
       - name: Upload asv results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -13,16 +13,35 @@ permissions:
   contents: read
 
 jobs:
+  # Matrix comes from .github/python-versions.json so the nightly, the PR
+  # gate and the test matrix cannot disagree about which versions exist.
+  versions:
+    name: Resolve Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.read.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read .github/python-versions.json
+        id: read
+        run: |
+          set -euo pipefail
+          # jq -e exits non-zero on a null result, and assigning a failed
+          # command substitution aborts under `set -e`, so a renamed key
+          # fails here instead of emitting an empty matrix that silently
+          # runs no benchmarks at all.
+          VERSIONS="$(jq -ce '.versions' .github/python-versions.json)"
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+
   benchmark:
-    name: asv run (Python ${{ matrix.python.version }})
+    name: asv run (Python ${{ matrix.python }})
+    needs: versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - version: "3.11"
-          - version: "3.12"
-          - version: "3.13"
+        python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -30,16 +49,16 @@ jobs:
 
       - uses: ./.github/actions/setup-pybroker
         with:
-          python-version: ${{ matrix.python.version }}
+          python-version: ${{ matrix.python }}
 
       - name: Configure asv machine identity
         env:
-          PY_VERSION: ${{ matrix.python.version }}
+          PY_VERSION: ${{ matrix.python }}
         run: asv machine --yes --machine "ci-ubuntu-latest-py${PY_VERSION}"
 
       - name: Run asv against master HEAD
         env:
-          PY_VERSION: ${{ matrix.python.version }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           set -o pipefail
           asv run HEAD^! \
@@ -52,12 +71,12 @@ jobs:
       # stayed green for weeks while only 3.11 did any work.
       - name: Assert benchmarks actually ran
         env:
-          PY_VERSION: ${{ matrix.python.version }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           # Match only "No environments selected". "No executable found for
-          # python X" is a warning the legs whose version differs from
-          # asv.conf.json's pin emit while still building an env from
-          # --python, so it is not on its own a failure.
+          # python X" is a warning asv also emits when it skips one unusable
+          # entry in asv.conf.json's `pythons` while still building an env
+          # from --python, so it is not on its own a failure.
           if grep -q "No environments selected" asv-run.log; then
             echo "::error::asv selected no environment for Python" \
                  "${PY_VERSION}. Nothing was benchmarked."
@@ -72,7 +91,7 @@ jobs:
       - name: Upload asv results
         uses: actions/upload-artifact@v7
         with:
-          name: asv-results-py${{ matrix.python.version }}-${{ github.run_id }}
+          name: asv-results-py${{ matrix.python }}-${{ github.run_id }}
           path: .asv/results/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -138,7 +138,7 @@ jobs:
           {
             echo "## ASV continuous — ${BASE_REF} → PR HEAD"
             echo ""
-            echo "Exit code: $ASV_EXIT (non-zero indicates flagged regression at --factor ${GATE_FACTOR})"
+            echo "Exit code: $ASV_EXIT (1 = flagged regression at --factor ${GATE_FACTOR}; 2 = a benchmark raised, nothing compared)"
             echo ""
             echo "### Moved by ${REPORT_FACTOR}x or more"
             echo ""
@@ -161,7 +161,7 @@ jobs:
           {
             echo "## ASV continuous — benchmark diff"
             echo ""
-            echo "Exit code: \`$ASV_EXIT\` (non-zero = flagged regression at \`--factor ${GATE_FACTOR}\`)"
+            echo "Exit code: \`$ASV_EXIT\` (\`1\` = flagged regression at \`--factor ${GATE_FACTOR}\`; \`2\` = a benchmark raised, so nothing was compared)"
             echo ""
             echo "**Moved by ${REPORT_FACTOR}x or more** — reported, not blocking:"
             echo ""
@@ -178,7 +178,9 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
-            if [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
+            if [ "$ASV_EXIT" = "2" ]; then
+              echo "_A benchmark raised an exception, so nothing was compared. \`bench-override\` does not apply — it accepts a measured slowdown, not a benchmark that cannot run._"
+            elif [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
               echo "_Gate forced green by \`bench-override\` label._"
             else
               echo "_Blocking at \`--factor ${GATE_FACTOR}\`, reporting from \`--factor ${REPORT_FACTOR}\`: 1.1 sits below this runner's noise floor, where identical code has flagged sub-2ms microbenchmarks at up to 1.18. Override via the \`bench-override\` PR label. For the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
@@ -203,6 +205,23 @@ jobs:
           if [ "$ASV_EXIT" = "0" ]; then
             echo "No regression flagged at ${GATE_FACTOR}x."
             exit 0
+          fi
+          # asv distinguishes the two non-zero exits and the gate must too.
+          # `asv run` returns 2 when any benchmark raised, and `asv
+          # continuous` propagates that immediately -- before it compares
+          # anything -- so exit 2 means "a benchmark is broken", not "this PR
+          # is slower". Reporting it as a regression is the same conflation
+          # that made a config drift look like one.
+          #
+          # bench-override deliberately does not apply here: it exists to
+          # accept a measured slowdown, not to merge a benchmark that cannot
+          # run.
+          if [ "$ASV_EXIT" = "2" ]; then
+            echo "::error::asv exited 2 -- at least one benchmark raised an" \
+                 "exception, so nothing was compared. This is not a" \
+                 "regression; the benchmark itself is broken."
+            grep -nE "failed" asv-continuous.log | head -20
+            exit 1
           fi
           if [ "$OVERRIDE" = "true" ]; then
             echo "Regression flagged (exit $ASV_EXIT) but 'bench-override' label is set — forcing green."

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -42,9 +42,17 @@ jobs:
           # comparisons, only factor and the median result", which disables
           # significance testing and lets an I/O-bound microbenchmark whose
           # error bars overlap trip --factor on noise alone.
+          # --interleave-rounds alternates rounds between the two commits
+          # instead of running each commit's rounds in a block, so drift over
+          # the job (thermal, noisy neighbours, page cache) hits both sides
+          # equally rather than landing entirely on "after". Without it a
+          # shared runner's second half reads as a regression: observed twice
+          # here on branches with byte-identical src/ and benchmarks/, each
+          # time flagging a different sub-100us benchmark.
           asv continuous "origin/${BASE_REF}" HEAD \
             --machine ci-ubuntu-latest \
             --factor 1.1 \
+            --interleave-rounds \
             >asv-continuous.log 2>&1
           EXIT=$?
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -21,7 +21,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Must match asv.conf.json's `pythons`. The setup action defaults to
+      # 3.12; when that drifts from the pin, asv finds no matching
+      # interpreter, selects no environments, and exits non-zero -- which the
+      # gate below reports as a regression while having benchmarked nothing.
       - uses: ./.github/actions/setup-pybroker
+        with:
+          python-version: "3.11"
 
       - name: Configure asv machine identity
         run: asv machine --yes --machine ci-ubuntu-latest

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -38,29 +38,60 @@ env:
   GATE_FACTOR: "1.25"
 
 jobs:
-  benchmark:
-    name: asv continuous
+  # Matrix comes from .github/python-versions.json, the same source the
+  # test matrix and the nightly read.
+  versions:
+    name: Resolve Python versions
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.read.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read .github/python-versions.json
+        id: read
+        run: |
+          set -euo pipefail
+          # jq -e exits non-zero on a null result, and assigning a failed
+          # command substitution aborts under `set -e`, so a renamed key
+          # fails here instead of emitting an empty matrix that silently
+          # runs no benchmarks at all.
+          VERSIONS="$(jq -ce '.versions' .github/python-versions.json)"
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+
+  # One leg per supported version. `asv continuous` benchmarks both commits
+  # in the same job on the same runner with the same interpreter, so each
+  # leg is self-contained -- no stored baseline, no results branch, no
+  # retention policy. That is what makes per-version regression detection
+  # affordable here and impossible in the nightly, whose legs use distinct
+  # machine identities and are not comparable to each other by design.
+  benchmark:
+    name: asv continuous (Python ${{ matrix.python }})
+    needs: versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      # Must match asv.conf.json's `pythons`. The setup action defaults to
-      # 3.12; when that drifts from the pin, asv finds no matching
-      # interpreter, selects no environments, and exits non-zero -- which the
-      # gate below reports as a regression while having benchmarked nothing.
       - uses: ./.github/actions/setup-pybroker
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python }}
 
       - name: Configure asv machine identity
-        run: asv machine --yes --machine ci-ubuntu-latest
+        env:
+          PY_VERSION: ${{ matrix.python }}
+        run: asv machine --yes --machine "ci-ubuntu-latest-py${PY_VERSION}"
 
       - name: Run asv continuous (base vs PR head)
         id: continuous
         env:
           BASE_REF: ${{ github.base_ref }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           set +e
           # No --no-stats: it means "do not use result statistics in
@@ -74,7 +105,8 @@ jobs:
           # existing rounds, so it costs no extra runtime. Neither flag is
           # sufficient on its own -- see GATE_FACTOR above.
           asv continuous "origin/${BASE_REF}" HEAD \
-            --machine ci-ubuntu-latest \
+            --python="${PY_VERSION}" \
+            --machine "ci-ubuntu-latest-py${PY_VERSION}" \
             --factor "${GATE_FACTOR}" \
             --interleave-rounds \
             >asv-continuous.log 2>&1
@@ -88,18 +120,21 @@ jobs:
       # apart -- a config drift therefore reads as a regression while nothing
       # was measured. Fail here with the real reason instead.
       - name: Assert benchmarks actually ran
+        env:
+          PY_VERSION: ${{ matrix.python }}
         run: |
           # Match only "No environments selected". "No executable found for
           # python X" is a warning asv also emits when it skips one unusable
-          # entry while still building an env from another, so it is not on
-          # its own a failure.
+          # entry in asv.conf.json's `pythons` while still building an env
+          # from --python, so it is not on its own a failure.
           if grep -q "No environments selected" asv-continuous.log; then
-            echo "::error::asv selected no environment -- the interpreter does" \
-                 "not match asv.conf.json's 'pythons'. Nothing was benchmarked."
+            echo "::error::asv selected no environment for Python" \
+                 "${PY_VERSION}. Nothing was benchmarked."
             exit 1
           fi
           if ! grep -qE "^\[[ 0-9]+\.[0-9]+%\]" asv-continuous.log; then
-            echo "::error::asv produced no benchmark results."
+            echo "::error::asv produced no benchmark results for Python" \
+                 "${PY_VERSION}."
             exit 1
           fi
 
@@ -110,10 +145,12 @@ jobs:
         id: compare
         env:
           BASE_REF: ${{ github.base_ref }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           set +e
           asv compare "origin/${BASE_REF}" HEAD \
-            --machine ci-ubuntu-latest \
+            --python="${PY_VERSION}" \
+            --machine "ci-ubuntu-latest-py${PY_VERSION}" \
             --factor "${REPORT_FACTOR}" \
             --only-changed \
             >asv-compare.log 2>&1
@@ -134,9 +171,10 @@ jobs:
         env:
           ASV_EXIT: ${{ steps.continuous.outputs.exit_code }}
           BASE_REF: ${{ github.base_ref }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           {
-            echo "## ASV continuous — ${BASE_REF} → PR HEAD"
+            echo "## ASV continuous (Python ${PY_VERSION}) — ${BASE_REF} → PR HEAD"
             echo ""
             echo "Exit code: $ASV_EXIT (1 = flagged regression at --factor ${GATE_FACTOR}; 2 = a benchmark raised, nothing compared)"
             echo ""
@@ -157,9 +195,10 @@ jobs:
         env:
           ASV_EXIT: ${{ steps.continuous.outputs.exit_code }}
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'bench-override') }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           {
-            echo "## ASV continuous — benchmark diff"
+            echo "## ASV continuous — benchmark diff (Python ${PY_VERSION})"
             echo ""
             echo "Exit code: \`$ASV_EXIT\` (\`1\` = flagged regression at \`--factor ${GATE_FACTOR}\`; \`2\` = a benchmark raised, so nothing was compared)"
             echo ""
@@ -187,6 +226,8 @@ jobs:
             fi
           } > sticky-comment.md
 
+      # One comment per version: the legs run in parallel, so a shared
+      # header would have them overwrite each other's results.
       - name: Post sticky PR comment
         # Skip for fork PRs — GITHUB_TOKEN is read-only for PRs from forks
         # and this step would fail with "Resource not accessible by integration".
@@ -194,16 +235,17 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v3
         with:
-          header: asv-continuous
+          header: asv-continuous-py${{ matrix.python }}
           path: sticky-comment.md
 
       - name: Enforce regression gate
         env:
           ASV_EXIT: ${{ steps.continuous.outputs.exit_code }}
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'bench-override') }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           if [ "$ASV_EXIT" = "0" ]; then
-            echo "No regression flagged at ${GATE_FACTOR}x."
+            echo "No regression flagged at ${GATE_FACTOR}x on Python ${PY_VERSION}."
             exit 0
           fi
           # asv distinguishes the two non-zero exits and the gate must too.

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -38,15 +38,38 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set +e
+          # No --no-stats: it means "do not use result statistics in
+          # comparisons, only factor and the median result", which disables
+          # significance testing and lets an I/O-bound microbenchmark whose
+          # error bars overlap trip --factor on noise alone.
           asv continuous "origin/${BASE_REF}" HEAD \
             --machine ci-ubuntu-latest \
             --factor 1.1 \
-            --no-stats \
             >asv-continuous.log 2>&1
           EXIT=$?
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
           cat asv-continuous.log
           exit 0
+
+      # asv exits non-zero both for a flagged regression and for having found
+      # no interpreter to benchmark with, and the gate below cannot tell those
+      # apart -- a config drift therefore reads as a regression while nothing
+      # was measured. Fail here with the real reason instead.
+      - name: Assert benchmarks actually ran
+        run: |
+          # Match only "No environments selected". "No executable found for
+          # python X" is a warning asv also emits when it skips one unusable
+          # entry while still building an env from another, so it is not on
+          # its own a failure.
+          if grep -q "No environments selected" asv-continuous.log; then
+            echo "::error::asv selected no environment -- the interpreter does" \
+                 "not match asv.conf.json's 'pythons'. Nothing was benchmarked."
+            exit 1
+          fi
+          if ! grep -qE "^\[[ 0-9]+\.[0-9]+%\]" asv-continuous.log; then
+            echo "::error::asv produced no benchmark results."
+            exit 1
+          fi
 
       - name: Write diff to job summary
         env:

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -12,6 +12,31 @@ permissions:
   contents: read
   pull-requests: write
 
+# Two thresholds, declared once so the flags and the prose describing them
+# cannot drift apart.
+#
+# REPORT_FACTOR is what gets shown: every benchmark that moved by 10% or
+# more lands in the PR comment for a human to read.
+#
+# GATE_FACTOR is what blocks the PR, and it is deliberately looser, because
+# 1.1 is below this runner's noise floor. Measured on six `asv continuous`
+# runs whose `src/` and `benchmarks/` were byte-identical between base and
+# head -- so every flagged result was noise:
+#
+#   1.18  CacheDiskHit.time_cache_disk_get            (429us)
+#   1.17  StoreBuildKernels...from_frame(10, 504)     (1.39ms)
+#   1.11  ModelPrepKernels.time_indicator_values...   (60us)
+#   1.11  ModelTrainPrep.time_train_models_per_symbol (1.92ms)
+#
+# One in six runs flagged something at 1.1, and every false positive was a
+# sub-2ms microbenchmark; the walkforward macrobenchmarks (100ms and up)
+# never moved. 1.25 clears the observed noise with margin. Raise the
+# sampling (`--attribute rounds=N`) rather than this number if that stops
+# being true -- loosening it further trades away real coverage.
+env:
+  REPORT_FACTOR: "1.1"
+  GATE_FACTOR: "1.25"
+
 jobs:
   benchmark:
     name: asv continuous
@@ -45,13 +70,12 @@ jobs:
           # --interleave-rounds alternates rounds between the two commits
           # instead of running each commit's rounds in a block, so drift over
           # the job (thermal, noisy neighbours, page cache) hits both sides
-          # equally rather than landing entirely on "after". Without it a
-          # shared runner's second half reads as a regression: observed twice
-          # here on branches with byte-identical src/ and benchmarks/, each
-          # time flagging a different sub-100us benchmark.
+          # equally rather than landing entirely on "after". It reuses the
+          # existing rounds, so it costs no extra runtime. Neither flag is
+          # sufficient on its own -- see GATE_FACTOR above.
           asv continuous "origin/${BASE_REF}" HEAD \
             --machine ci-ubuntu-latest \
-            --factor 1.1 \
+            --factor "${GATE_FACTOR}" \
             --interleave-rounds \
             >asv-continuous.log 2>&1
           EXIT=$?
@@ -79,6 +103,33 @@ jobs:
             exit 1
           fi
 
+      # Reads the results the step above already stored -- no benchmark is
+      # re-run, so the reporting threshold costs nothing. Non-fatal: a
+      # missing table must not fail a PR that the gate passed.
+      - name: Compare at the reporting threshold
+        id: compare
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set +e
+          asv compare "origin/${BASE_REF}" HEAD \
+            --machine ci-ubuntu-latest \
+            --factor "${REPORT_FACTOR}" \
+            --only-changed \
+            >asv-compare.log 2>&1
+          RC=$?
+          if [ "$RC" -ne 0 ]; then
+            echo "" >>asv-compare.log
+            echo "(asv compare exited ${RC}; the table above may be" \
+                 "incomplete. The gate verdict is unaffected.)" \
+              >>asv-compare.log
+          elif [ ! -s asv-compare.log ]; then
+            echo "No benchmark moved by ${REPORT_FACTOR}x or more." \
+              >asv-compare.log
+          fi
+          cat asv-compare.log
+          exit 0
+
       - name: Write diff to job summary
         env:
           ASV_EXIT: ${{ steps.continuous.outputs.exit_code }}
@@ -87,7 +138,15 @@ jobs:
           {
             echo "## ASV continuous — ${BASE_REF} → PR HEAD"
             echo ""
-            echo "Exit code: $ASV_EXIT (non-zero indicates flagged regression at --factor 1.1)"
+            echo "Exit code: $ASV_EXIT (non-zero indicates flagged regression at --factor ${GATE_FACTOR})"
+            echo ""
+            echo "### Moved by ${REPORT_FACTOR}x or more"
+            echo ""
+            echo '```'
+            cat asv-compare.log
+            echo '```'
+            echo ""
+            echo "### Full run"
             echo ""
             echo '```'
             cat asv-continuous.log
@@ -102,10 +161,16 @@ jobs:
           {
             echo "## ASV continuous — benchmark diff"
             echo ""
-            echo "Exit code: \`$ASV_EXIT\` (non-zero = flagged regression at \`--factor 1.1\`)"
+            echo "Exit code: \`$ASV_EXIT\` (non-zero = flagged regression at \`--factor ${GATE_FACTOR}\`)"
+            echo ""
+            echo "**Moved by ${REPORT_FACTOR}x or more** — reported, not blocking:"
+            echo ""
+            echo '```'
+            cat asv-compare.log
+            echo '```'
             echo ""
             echo "<details>"
-            echo "<summary>Benchmark output</summary>"
+            echo "<summary>Full benchmark output</summary>"
             echo ""
             echo '```'
             cat asv-continuous.log
@@ -116,7 +181,7 @@ jobs:
             if [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
               echo "_Gate forced green by \`bench-override\` label._"
             else
-              echo "_Blocking at \`--factor 1.1\`; override via the \`bench-override\` PR label. Shared GitHub runners are noisy — for the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
+              echo "_Blocking at \`--factor ${GATE_FACTOR}\`, reporting from \`--factor ${REPORT_FACTOR}\`: 1.1 sits below this runner's noise floor, where identical code has flagged sub-2ms microbenchmarks at up to 1.18. Override via the \`bench-override\` PR label. For the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
             fi
           } > sticky-comment.md
 
@@ -136,7 +201,7 @@ jobs:
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'bench-override') }}
         run: |
           if [ "$ASV_EXIT" = "0" ]; then
-            echo "No regression flagged."
+            echo "No regression flagged at ${GATE_FACTOR}x."
             exit 0
           fi
           if [ "$OVERRIDE" = "true" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,60 @@ on:
   - push
 
 jobs:
-  format:
-    name: Check formatting
+  # Single source of truth for every Python version this workflow uses.
+  # `versions` drives the test matrix; `tooling` pins the one interpreter
+  # that runs format, lint, typecheck, docs and the sdist build. Editing
+  # .github/python-versions.json changes all of them at once.
+  versions:
+    name: Resolve Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.read.outputs.versions }}
+      tooling: ${{ steps.read.outputs.tooling }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read .github/python-versions.json
+        id: read
+        run: |
+          set -euo pipefail
+          # jq -e exits non-zero on a null result, and assigning a failed
+          # command substitution aborts under `set -e`, so a renamed or
+          # mistyped key fails here instead of silently emitting an empty
+          # matrix that skips every leg. Interpolating jq directly into
+          # `echo` would swallow that exit status.
+          VERSIONS="$(jq -ce '.versions' .github/python-versions.json)"
+          TOOLING="$(jq -re '.tooling' .github/python-versions.json)"
+          {
+            echo "versions=${VERSIONS}"
+            echo "tooling=${TOOLING}"
+          } >> "$GITHUB_OUTPUT"
+
+  # The sites below cannot read the JSON. This asserts they agree with it.
+  verify-versions:
+    name: Verify version declarations
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
+
+      - name: Check declaration sites against the matrix
+        run: python .github/scripts/check_python_versions.py
+
+  format:
+    name: Check formatting
+    needs: versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
@@ -22,13 +67,14 @@ jobs:
 
   lint:
     name: Lint
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
@@ -38,13 +84,14 @@ jobs:
 
   typecheck:
     name: Type check
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
@@ -54,13 +101,14 @@ jobs:
 
   docs:
     name: Build docs
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install pandoc
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pandoc
@@ -73,40 +121,41 @@ jobs:
 
   test:
     name: Test
+    needs: versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - version: "3.12"
-            toxenv: "py312"
-          - version: "3.11"
-            toxenv: "py311"
-          - version: "3.13"
-            toxenv: "py313"
+        python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python.version }}
+          python-version: ${{ matrix.python }}
           allow-prereleases: true
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
 
+      # The tox env name is derived, never stored, so it cannot drift from
+      # the matrix. setup.cfg's envlist is held to the same list by
+      # verify-versions.
       - name: Run pytest
-        run: tox -e ${{ matrix.python.toxenv }}
+        env:
+          PY_VERSION: ${{ matrix.python }}
+        run: tox -e "py${PY_VERSION//./}"
 
   build_source_dist:
       name: Build source distribution
+      needs: versions
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v7
 
         - uses: actions/setup-python@v7
           with:
-            python-version: "3.12"
+            python-version: ${{ needs.versions.outputs.tooling }}
 
         - name: Install build
           run: python -m pip install build
@@ -122,6 +171,7 @@ jobs:
     name: Publish package
     if: startsWith(github.event.ref, 'refs/tags/v')
     needs:
+      - verify-versions
       - format
       - lint
       - typecheck

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -5,15 +5,60 @@ on:
     - cron: '0 12 * * *'
 
 jobs:
-  format:
-    name: Check formatting
+  # Single source of truth for every Python version this workflow uses.
+  # `versions` drives the test matrix; `tooling` pins the one interpreter
+  # that runs format, lint, typecheck, docs and the sdist build. Editing
+  # .github/python-versions.json changes all of them at once.
+  versions:
+    name: Resolve Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.read.outputs.versions }}
+      tooling: ${{ steps.read.outputs.tooling }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read .github/python-versions.json
+        id: read
+        run: |
+          set -euo pipefail
+          # jq -e exits non-zero on a null result, and assigning a failed
+          # command substitution aborts under `set -e`, so a renamed or
+          # mistyped key fails here instead of silently emitting an empty
+          # matrix that skips every leg. Interpolating jq directly into
+          # `echo` would swallow that exit status.
+          VERSIONS="$(jq -ce '.versions' .github/python-versions.json)"
+          TOOLING="$(jq -re '.tooling' .github/python-versions.json)"
+          {
+            echo "versions=${VERSIONS}"
+            echo "tooling=${TOOLING}"
+          } >> "$GITHUB_OUTPUT"
+
+  # The sites below cannot read the JSON. This asserts they agree with it.
+  verify-versions:
+    name: Verify version declarations
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
+
+      - name: Check declaration sites against the matrix
+        run: python .github/scripts/check_python_versions.py
+
+  format:
+    name: Check formatting
+    needs: versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
@@ -23,13 +68,14 @@ jobs:
 
   lint:
     name: Lint
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
@@ -39,13 +85,14 @@ jobs:
 
   typecheck:
     name: Type check
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
@@ -55,13 +102,14 @@ jobs:
 
   docs:
     name: Build docs
+    needs: versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ needs.versions.outputs.tooling }}
 
       - name: Install pandoc
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pandoc
@@ -74,40 +122,41 @@ jobs:
 
   test:
     name: Test
+    needs: versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - version: "3.12"
-            toxenv: "py312"
-          - version: "3.11"
-            toxenv: "py311"
-          - version: "3.13"
-            toxenv: "py313"
+        python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python.version }}
+          python-version: ${{ matrix.python }}
           allow-prereleases: true
 
       - name: Install tox
         run: python -m pip install --no-cache-dir tox
 
+      # The tox env name is derived, never stored, so it cannot drift from
+      # the matrix. setup.cfg's envlist is held to the same list by
+      # verify-versions.
       - name: Run pytest
-        run: tox -e ${{ matrix.python.toxenv }}
+        env:
+          PY_VERSION: ${{ matrix.python }}
+        run: tox -e "py${PY_VERSION//./}"
 
   build_source_dist:
       name: Build source distribution
+      needs: versions
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v7
 
         - uses: actions/setup-python@v7
           with:
-            python-version: "3.12"
+            python-version: ${{ needs.versions.outputs.tooling }}
 
         - name: Install build
           run: python -m pip install build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ tox -e py311,py312,py313  # full test matrix
 
 # Benchmarks (asv; see Performance & Benchmarks)
 asv run --quick             # fast feedback, one sample per benchmark
-asv continuous master HEAD  # what the CI PR gate runs (--factor 1.1)
+asv continuous master HEAD  # what the CI PR gate runs (blocks at --factor 1.25)
 
 # Docs — CI runs `tox -e docs` on Python 3.12; it is STRICT
 # (`sphinx-build -n -W --keep-going`), so any warning fails the build.
@@ -280,8 +280,10 @@ between runs on NumPy arrays and Numba kernels.
   against `master`). Process doc: `docs/source/benchmarking.rst`.
 - **Perf-sensitive change → run the relevant benches before and after:**
   `asv continuous master HEAD` (a targeted `--bench <pattern>` pass first
-  is fine). CI fails PRs on regressions > 1.1× unless the PR carries the
-  `bench-override` label. **New hot path → add a benchmark.**
+  is fine). CI blocks PRs on regressions > 1.25× unless the PR carries the
+  `bench-override` label, and reports everything > 1.1× without blocking —
+  1.1 sits below the shared runner's noise floor. **New hot path → add a
+  benchmark.**
 - `WalkforwardCold` intentionally includes Numba JIT compile time — it
   validates the `cache=True` contract. Never add warmup to it.
 - Ad-hoc JSON-baseline runners exist for targeted comparisons
@@ -433,7 +435,7 @@ done.
 7. If indicators, scopes, or context slicing were touched:
    `python -m pytest tests/test_vect.py -k look_ahead`
 8. If perf-sensitive: `asv continuous master HEAD` — no regression
-   > 1.1×.
+   > 1.25× (the blocking threshold); investigate anything > 1.1×.
 9. If the public API changed: export added in `__init__.py`, docstrings
    complete, `:exclude-members:` in `pybroker.strategy.rst` updated.
 10. If `skills/`, public signatures/docstrings in `src/`, or the doc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,14 @@ between runs on NumPy arrays and Numba kernels.
   (`scripts/bench_interval.py` + `.bench/timeframe-baseline.json`, and
   `benchmarks/run_*.py`); keep their baselines valid when touching those
   paths.
+- **The CI Python matrix is single-sourced** in
+  `.github/python-versions.json` (`versions` = the test matrix, the asv PR
+  gate and the asv nightly; `tooling` = format/lint/typecheck/docs/sdist).
+  Workflows read it with `fromJSON()`; `setup.cfg`, `asv.conf.json`,
+  `pyproject.toml` and `.readthedocs.yml` cannot, so
+  `.github/scripts/check_python_versions.py` fails CI when they drift.
+  Adding or dropping a version means editing the JSON and whatever that
+  check reports — never a workflow literal.
 
 ## Docs
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -8,7 +8,7 @@
   "environment_type": "virtualenv",
   "install_timeout": 600,
   "show_commit_url": "https://github.com/edtechre/pybroker/commit/",
-  "pythons": ["3.11"],
+  "pythons": ["3.11", "3.12", "3.13"],
   "install_command": [
     "in-dir={build_dir} python -mpip install -e ."
   ],

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -7,9 +7,11 @@ per-commit results under ``.asv/results/``, and produces an HTML
 dashboard for visual regression tracking.
 
 The benchmark suite lives in ``benchmarks/`` and is exercised in CI on
-every pull request via ``.github/workflows/asv-pr.yml`` (uses
-``asv continuous origin/master HEAD`` and posts a sticky PR comment with
-the diff).
+every pull request via ``.github/workflows/asv-pr.yml``, which runs
+``asv continuous origin/master HEAD`` once per supported Python version
+and posts a sticky PR comment per version with the diff. The versions
+come from ``.github/python-versions.json``, the single source of truth
+the test matrix and the nightly benchmark run read as well.
 
 Installation
 ------------
@@ -106,6 +108,19 @@ Environment
 ``asv.conf.json`` uses ``environment_type: virtualenv`` so each commit is
 benchmarked in a fresh virtualenv built from ``setup.cfg``. The install
 command is ``python -mpip install -e .``: no Poetry, no tox; just pip.
+
+Its ``pythons`` lists every supported version, kept in step with
+``.github/python-versions.json`` by
+``.github/scripts/check_python_versions.py``. asv builds one environment
+per entry it can find an interpreter for, so a local run covers whichever
+of those versions is installed; pass ``--python`` to pick a single one:
+
+.. code-block:: bash
+
+   asv run --python=3.12
+   asv continuous master HEAD --python=3.12
+
+CI always passes ``--python`` explicitly, one version per matrix leg.
 
 For local ad-hoc benchmarking you can switch the config to
 ``environment_type: existing`` (uses the currently activated venv) to

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -36,12 +36,22 @@ Compare two commits:
    asv continuous master HEAD   # local equivalent of the CI gate
    asv compare master HEAD      # diff table
 
-The PR gate adds ``--factor 1.1 --no-stats --machine ci-ubuntu-latest`` and
+The PR gate adds
+``--factor 1.1 --interleave-rounds --machine ci-ubuntu-latest`` and
 resolves the base as ``origin/<base branch>``:
 
 .. code-block:: bash
 
-   asv continuous origin/master HEAD --factor 1.1 --no-stats
+   asv continuous origin/master HEAD --factor 1.1 --interleave-rounds
+
+``--interleave-rounds`` alternates rounds between the two commits instead
+of running each commit's rounds in a block, so drift over the job
+(thermal throttling, noisy neighbours, page cache) hits both sides
+equally instead of landing entirely on whichever commit ran second. On a
+shared runner, omitting it makes microsecond-scale benchmarks read as
+regressions on branches with identical code. ``--no-stats`` is
+deliberately *not* used: it disables significance testing, comparing raw
+medians against ``--factor`` alone.
 
 Generate and preview the HTML dashboard:
 

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -36,22 +36,38 @@ Compare two commits:
    asv continuous master HEAD   # local equivalent of the CI gate
    asv compare master HEAD      # diff table
 
-The PR gate adds
-``--factor 1.1 --interleave-rounds --machine ci-ubuntu-latest`` and
-resolves the base as ``origin/<base branch>``:
+The PR gate uses two thresholds. It blocks at ``--factor 1.25`` and
+reports everything that moved by ``1.1`` or more, resolving the base as
+``origin/<base branch>``:
 
 .. code-block:: bash
 
-   asv continuous origin/master HEAD --factor 1.1 --interleave-rounds
+   asv continuous origin/master HEAD --factor 1.25 --interleave-rounds
+   asv compare origin/master HEAD --factor 1.1 --only-changed
 
+The second command re-reads the results the first one stored, so it costs
+no extra benchmarking.
+
+Why the gate is looser than the report: ``1.1`` is below a shared
+runner's noise floor. Across six ``asv continuous`` runs whose ``src/``
+and ``benchmarks/`` were byte-identical between base and head, one run
+still flagged a regression — always a sub-2ms microbenchmark, at ratios
+up to ``1.18``. The walkforward macrobenchmarks (100ms and up) never
+moved. Gating at ``1.25`` clears the measured noise; the ``1.1`` table
+keeps the smaller movements visible for a human to judge.
+
+Two flags do part of the work but are not sufficient alone.
 ``--interleave-rounds`` alternates rounds between the two commits instead
 of running each commit's rounds in a block, so drift over the job
 (thermal throttling, noisy neighbours, page cache) hits both sides
-equally instead of landing entirely on whichever commit ran second. On a
-shared runner, omitting it makes microsecond-scale benchmarks read as
-regressions on branches with identical code. ``--no-stats`` is
-deliberately *not* used: it disables significance testing, comparing raw
-medians against ``--factor`` alone.
+equally instead of landing entirely on whichever commit ran second; it
+reuses the existing rounds, so it is free. ``--no-stats`` is deliberately
+*not* used: it disables significance testing, comparing raw medians
+against ``--factor`` alone.
+
+If the noise floor rises, raise the sampling
+(``--attribute rounds=N``) rather than the gate factor — loosening the
+factor trades away real coverage.
 
 Generate and preview the HTML dashboard:
 
@@ -64,8 +80,9 @@ Benchmark Suite
 ---------------
 
 The asv suite lives in ``benchmarks/`` across four modules. CI fails PRs on
-regressions greater than 1.1x unless the PR carries the ``bench-override``
-label. New hot paths should add a benchmark.
+regressions greater than 1.25x unless the PR carries the ``bench-override``
+label, and reports anything above 1.1x without blocking. New hot paths
+should add a benchmark.
 
 - ``bench_backtest.py`` - end-to-end walkforward (warm, cold, scaled,
   models, intervals, slippage-free) plus microbenchmarks for the indicator


### PR DESCRIPTION
Follow-up to #287, which repaired the asv gate. That PR fixed the symptom; this one removes the conditions that produced it.

> **Stacked on #287.** Until that merges, this diff also shows its four commits. Once it lands I rebase and this reduces to the source-of-truth change alone. Merge order is spelled out in #287.

## The problem

The Python matrix exists as 18 hand-synced literals across four workflows, a composite action default, `setup.cfg`, `asv.conf.json`, `pyproject.toml` and `.readthedocs.yml`. There is no `fromJSON` anywhere, and `main.yml` and `schedule.yml` carry byte-identical, independently maintained copies of the same matrix.

That is exactly how #287's bug happened: `37848d6` changed `asv.conf.json`'s `pythons` and the workflows kept resolving a different interpreter.

Separately, **regressions on anything but one Python version are caught by nothing.** The PR gate benchmarks a single version. The nightly runs three but only uploads a 30-day artifact — no baseline, no comparison, no failure condition — and `.asv/` is gitignored, so no history accumulates to compare against either.

## What this does

**1. `.github/python-versions.json` is the source of truth.**

```json
{ "versions": ["3.11", "3.12", "3.13"], "tooling": "3.12" }
```

`versions` drives the test matrix, the asv PR gate and the asv nightly. `tooling` is the one interpreter for format / lint / typecheck / docs / sdist. A `versions` job emits both via `$GITHUB_OUTPUT`; consumers read them with `fromJSON()`. The tox env name is *derived* (`3.11` → `py311`), never stored, so it cannot drift.

**2. `verify-versions` holds the sites that cannot read JSON.**

`.github/scripts/check_python_versions.py` (stdlib only, runnable locally) asserts `asv.conf.json`'s `pythons`, `setup.cfg`'s `envlist` / `python_requires` floor / `[mypy] python_version` / typecheck `basepython`, `.readthedocs.yml`'s build pin and ruff's `target-version` all agree with the JSON. It runs on every push and `publish` now depends on it.

**3. The PR gate runs on every version.**

`asv continuous` benchmarks both commits in the same job, on the same runner, with the same interpreter — so each leg is self-contained and needs no stored baseline. Widening it across the matrix buys per-version regression detection with **no results branch, no artifact chaining, no retention policy**. The legs run in parallel, so wall clock is unchanged.

This is deliberately not done in the nightly: its legs use distinct asv machine identities, land on different runner VMs and measure different CPython baselines, so a cross-version delta there measures CPython, not pybroker.

**4. The composite action's default is gone.**

`python-version` was defaulted to `"3.12"` — precisely the value that diverged. It is now required. Note that GitHub does *not* enforce `required` for composite action inputs: an omitted input arrives as the empty string and `setup-python` would silently fall back to the runner's default. The action therefore fails explicitly on an empty value.

## Heads-up on branch protection

The gate's check name changes from `asv continuous` to `asv continuous (Python 3.11)` / `(Python 3.12)` / `(Python 3.13)`. If a branch protection rule requires the old name, it needs updating — I can't see those settings from here.

## Verification

Everything below was run on a fork before opening.

- **Package** — `versions` and `verify-versions` green; all three test legs green off the JSON-driven matrix, named `Test (3.11)` / `(3.12)` / `(3.13)` from the source of truth.
- **asv PR gate, all three legs** — full suite each (128 result rows = 64 benchmarks x 2 commits), guard step passed, no regression flagged.
- **asv nightly** — all three legs to `[100.00%]` with identical benchmark counts (64 rows each), guard passed in every leg.
- **The drift check actually fails**, which is the only thing that makes it worth having: desyncing `setup.cfg`'s `envlist` from the JSON, and setting `tooling` to a version not in `versions`, each exit 1 naming the specific site.
- **`asv continuous --python` confirmed supported** (`Same as --environment=:PYTHON`) rather than assumed.

The three-leg run also produced the sharpest evidence for #287's noise finding: on one commit pair with identical `src/`, the same benchmark read 1.12 on the 3.11 leg and 0.83 on the 3.12 leg. Running the gate on several interpreters at once makes runner noise visible in a way a single leg cannot.

Python 3.14 is a one-entry follow-up on top of this (numba 0.66 supports it; 3.15 has no numba support yet), sent separately so it can be judged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
