### PR TITLE
ci: repair the asv PR gate — it is failing on every PR

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -71,12 +71,12 @@ jobs:
       # stayed green for weeks while only 3.11 did any work.
       - name: Assert benchmarks actually ran
         env:
-          PY_VERSION: ${{ matrix.python.version }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           # Match only "No environments selected". "No executable found for
-          # python X" is a warning the legs whose version differs from
-          # asv.conf.json's pin emit while still building an env from
-          # --python, so it is not on its own a failure.
+          # python X" is a warning asv also emits when it skips one unusable
+          # entry in asv.conf.json's `pythons` while still building an env
+          # from --python, so it is not on its own a failure.
           if grep -q "No environments selected" asv-run.log; then
             echo "::error::asv selected no environment for Python" \
                  "${PY_VERSION}. Nothing was benchmarked."

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -78,13 +78,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Must match asv.conf.json's `pythons`. The setup action defaults to
-      # 3.12; when that drifts from the pin, asv finds no matching
-      # interpreter, selects no environments, and exits non-zero -- which the
-      # gate below reports as a regression while having benchmarked nothing.
       - uses: ./.github/actions/setup-pybroker
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python }}
 
       - name: Configure asv machine identity
         env:
@@ -109,7 +105,8 @@ jobs:
           # existing rounds, so it costs no extra runtime. Neither flag is
           # sufficient on its own -- see GATE_FACTOR above.
           asv continuous "origin/${BASE_REF}" HEAD \
-            --machine ci-ubuntu-latest \
+            --python="${PY_VERSION}" \
+            --machine "ci-ubuntu-latest-py${PY_VERSION}" \
             --factor "${GATE_FACTOR}" \
             --interleave-rounds \
             >asv-continuous.log 2>&1
@@ -123,18 +120,21 @@ jobs:
       # apart -- a config drift therefore reads as a regression while nothing
       # was measured. Fail here with the real reason instead.
       - name: Assert benchmarks actually ran
+        env:
+          PY_VERSION: ${{ matrix.python }}
         run: |
           # Match only "No environments selected". "No executable found for
           # python X" is a warning asv also emits when it skips one unusable
-          # entry while still building an env from another, so it is not on
-          # its own a failure.
+          # entry in asv.conf.json's `pythons` while still building an env
+          # from --python, so it is not on its own a failure.
           if grep -q "No environments selected" asv-continuous.log; then
-            echo "::error::asv selected no environment -- the interpreter does" \
-                 "not match asv.conf.json's 'pythons'. Nothing was benchmarked."
+            echo "::error::asv selected no environment for Python" \
+                 "${PY_VERSION}. Nothing was benchmarked."
             exit 1
           fi
           if ! grep -qE "^\[[ 0-9]+\.[0-9]+%\]" asv-continuous.log; then
-            echo "::error::asv produced no benchmark results."
+            echo "::error::asv produced no benchmark results for Python" \
+                 "${PY_VERSION}."
             exit 1
           fi
 
@@ -145,10 +145,12 @@ jobs:
         id: compare
         env:
           BASE_REF: ${{ github.base_ref }}
+          PY_VERSION: ${{ matrix.python }}
         run: |
           set +e
           asv compare "origin/${BASE_REF}" HEAD \
-            --machine ci-ubuntu-latest \
+            --python="${PY_VERSION}" \
+            --machine "ci-ubuntu-latest-py${PY_VERSION}" \
             --factor "${REPORT_FACTOR}" \
             --only-changed \
             >asv-compare.log 2>&1
@@ -173,8 +175,6 @@ jobs:
         run: |
           {
             echo "## ASV continuous (Python ${PY_VERSION}) — ${BASE_REF} → PR HEAD"
-            echo ""
-            echo "Exit code: $ASV_EXIT (1 = flagged regression at --factor ${GATE_FACTOR}; 2 = a benchmark raised, nothing compared)"
             echo ""
             echo "Exit code: $ASV_EXIT (1 = flagged regression at --factor ${GATE_FACTOR}; 2 = a benchmark raised, nothing compared)"
             echo ""
@@ -245,7 +245,7 @@ jobs:
           PY_VERSION: ${{ matrix.python }}
         run: |
           if [ "$ASV_EXIT" = "0" ]; then
-            echo "No regression flagged at ${GATE_FACTOR}x."
+            echo "No regression flagged at ${GATE_FACTOR}x on Python ${PY_VERSION}."
             exit 0
           fi
           # asv distinguishes the two non-zero exits and the gate must too.


### PR DESCRIPTION
**The asv PR gate is down on `dev` right now — every pull request gets zero benchmarks.** This restores it.

#288's merge resolved the workflow conflicts toward the pre-matrix versions. I first read the result as merely decorative — a matrix whose legs all run 3.11 — but it is worse than that: the job fails outright.

## What `dev` does right now

| | on `dev` | intended |
|---|---|---|
| `setup-pybroker` | `python-version: "3.11"` | `${{ matrix.python }}` |
| `asv continuous` | `--machine ci-ubuntu-latest`, no `--python` | `--python`, `--machine …-py<ver>` |
| `asv compare` | same | same |
| nightly guard | `matrix.python.version` (empty) | `matrix.python` |
| job summary | `Exit code` line printed twice | once |

## Why it fails, not just degrades

`asv machine` still registers the per-version identity while `asv continuous` and `asv compare` ask for the bare one. asv does not fall back — it stops:

```
· No information stored about machine 'ci-ubuntu-latest'.
  I know about 'ci-ubuntu-latest-py3.11'.
· Run asv at the console the first time to generate one, or run `asv machine --yes`.
```

Every leg, every PR. Live example: all four legs of #290 failed this way minutes ago.

The failure is at least loud rather than silent — the "assert benchmarks actually ran" guard reports `asv produced no benchmark results` instead of the old behaviour of reporting a phantom regression. But no PR is being benchmarked until this lands.

Had the machine identity happened to match, the remaining damage would still have been real: all three legs would run 3.11 while reporting checks named `(Python 3.11)`, `(3.12)`, `(3.13)` — three green ticks asserting coverage that does not exist.

## What this does

Restores the file content that the three-leg fork run verified before the merge — the version where all three legs genuinely ran their own interpreter (full suite each, 128 result rows per leg, guard passed, no regression flagged).

No new work and no behaviour beyond what #288 already intended.

## Note

Nothing here is a criticism of the resolution — a conflict between "single version" and "matrix over versions" resolves toward the wrong side very easily, and the duplicated `Exit code` line suggests it was a mechanical resolve rather than a considered one. Flagging it because it fails silently: nothing in CI complains about a matrix whose legs are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
