### PR TITLE
ci: add Python 3.14 to the supported matrix

### DIFF
--- a/.github/python-versions.json
+++ b/.github/python-versions.json
@@ -9,6 +9,6 @@
     ".github/scripts/check_python_versions.py, which CI runs on every push.",
     "Adding a version is one entry here plus whatever that check reports."
   ],
-  "versions": ["3.11", "3.12", "3.13"],
+  "versions": ["3.11", "3.12", "3.13", "3.14"],
   "tooling": "3.12"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ python -m pytest -p no:randomly ...        # deterministic order when bisecting 
 tox -e format             # ruff format --diff — CHECK ONLY; `tox -e format -- src tests` to write
 tox -e lint               # ruff check src tests
 tox -e typecheck          # mypy on src (mypy version pinned in the tox env)
-tox -e py311,py312,py313  # full test matrix
+tox -e py311,py312,py313,py314  # full test matrix
 
 # Benchmarks (asv; see Performance & Benchmarks)
 asv run --quick             # fast feedback, one sample per benchmark

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -8,7 +8,7 @@
   "environment_type": "virtualenv",
   "install_timeout": 600,
   "show_commit_url": "https://github.com/edtechre/pybroker/commit/",
-  "pythons": ["3.11", "3.12", "3.13"],
+  "pythons": ["3.11", "3.12", "3.13", "3.14"],
   "install_command": [
     "in-dir={build_dir} python -mpip install -e ."
   ],

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ namespace_packages = True
 check_untyped_defs = True
 
 [tox:tox]
-envlist = py311,py312,py313
+envlist = py311,py312,py313,py314
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
**Draft — opening as WIP.**

Adds Python 3.14 to the supported matrix. Four one-line changes, which is the point: #288 made the version list a single source of truth, so adding a version is an entry in `.github/python-versions.json` plus the sites the consistency check names.

```diff
-  "versions": ["3.11", "3.12", "3.13"],
+  "versions": ["3.11", "3.12", "3.13", "3.14"],
```

…plus `setup.cfg`'s `envlist`, `asv.conf.json`'s `pythons`, and the matrix line in `CLAUDE.md`.

The check earned its keep on first real use: it caught `asv.conf.json`'s `pythons`, which is exactly the site that is easy to forget because nothing else reads it — and forgetting it is the bug that started this whole thread.

## Dependency support

Every compiled dependency publishes a cp314 wheel; everything else is pure Python:

| package | version | cp314 wheel |
|---|---|---|
| numba | 0.66.0 | ✅ |
| numpy | 2.5.1 | ✅ |
| pandas | 3.0.5 | ✅ |
| ray (test extra) | 2.56.1 | ✅ |
| arch (test extra) | 8.0.0 | ✅ |
| optuna, alpaca-py, yfinance, yahooquery, akshare, diskcache, joblib, progressbar2 | — | pure Python |

**3.15 is not addable yet** — numba has no 3.15 classifier.

## Verification

Run on a fork:

- **Full test matrix green including `Test (3.14)`** — the whole suite, not a smoke subset, with numba, pandas 3 and ray on 3.14.
- **`verify-versions` green** after the four sites agree.
- **asv gate, 4 legs** including a real `asv continuous (Python 3.14)` — running now on the fork, where the matrix wiring is intact. This is the part still outstanding: it checks that asv can build a 3.14 environment and compile the numba kernels, not merely that the tests import. I will report the result here rather than assume it.

Staying a draft until that leg reports.

## Ordering: after #289

Not a hard dependency — the two PRs touch disjoint files (#289 is workflow wiring, this is version literals), so either merge order is safe and neither conflicts with the other.

It is an ordering preference. The 3.14 **test** leg works on `dev` today; `main.yml` was never affected by #288's merge. The 3.14 **benchmark** leg does nothing distinct until #289 lands, because `asv-pr.yml` on `dev` currently pins `python-version: "3.11"` for every leg — a fourth leg would benchmark 3.11 like the other three. Merging this first is harmless, it just adds ~16 min of CI that measures nothing new until #289 is in.

No rush on this one — it is deliberately separable so that a dependency which is not ready on 3.14 blocks nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
