### PR TITLE
ci: gate benchmarks on duration as well as ratio

### DIFF
--- a/.github/scripts/asv_gate.py
+++ b/.github/scripts/asv_gate.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Decide the benchmark gate from asv's stored results.
+
+A plain ``--factor`` gate does not work on shared CI runners. Measured
+across roughly ten ``asv continuous`` legs whose ``src/`` and
+``benchmarks/`` were byte-identical between base and head -- so every
+flagged result was noise:
+
+    1.29  EvalKernels.time_sharpe_ratio                 16.5us
+    1.18  CacheDiskHit.time_cache_disk_get               429us
+    1.17  StoreBuildKernels...from_frame(10, 504)       1.39ms
+    1.12  IndicatorKernels.time_cross(1000)             7.25us
+    1.11  ModelPrepKernels.time_indicator_values...       60us
+    1.11  ModelTrainPrep.time_train_models_per_symbol   1.92ms
+    0.65  CacheDiskHit.time_cache_disk_get               633us
+
+Every one is under 2ms, and the same benchmark has read 1.12 on one leg
+and 0.83 on another *in the same run*. The walkforward macrobenchmarks
+(100ms and up) have never been flagged. So the noise is a property of how
+short the benchmark is, not of the threshold: no factor separates signal
+from noise down there, it only trades false positives for blindness.
+
+This gates on both axes. A benchmark blocks only when it is slow enough
+to measure on a noisy runner *and* it regressed past the factor.
+Everything else is reported, so a real microbenchmark regression stays
+visible to a human -- it just does not block a PR on a coin flip.
+
+Results come from asv's own API (``asv.results``), which reads the JSON
+it already wrote under ``.asv/results/``. Values arrive as floats in
+seconds, so there is no rendered table to parse and no units to convert.
+"""
+
+import argparse
+import itertools
+import sys
+from typing import NamedTuple
+
+from asv.config import Config
+from asv.results import iter_results_for_machine_and_hash
+
+
+def format_seconds(seconds: float) -> str:
+    """Renders a duration in whichever unit reads most naturally."""
+    for unit, scale in (("s", 1.0), ("ms", 1e-3), ("us", 1e-6)):
+        if seconds >= scale:
+            return f"{seconds / scale:g}{unit}"
+    return f"{seconds / 1e-9:g}ns"
+
+
+class Change(NamedTuple):
+    """One benchmark's before/after timing, both in seconds."""
+
+    name: str
+    before: float
+    after: float
+
+    @property
+    def ratio(self) -> float:
+        return self.after / self.before
+
+
+def load_timings(
+    results_dir: str, machine: str, commit: str
+) -> dict[str, float]:
+    """Maps benchmark name (with parameters) to its time in seconds.
+
+    Parameterized benchmarks yield one entry per parameter combination,
+    keyed the way asv names them -- ``bench.Class.time_x(4, 12)`` -- so
+    a regression in one combination is not averaged away by the others.
+    """
+    timings: dict[str, float] = {}
+    for result in iter_results_for_machine_and_hash(
+        results_dir, machine, commit
+    ):
+        for name in result.get_all_result_keys():
+            params = result.get_result_params(name)
+            # Always a list -- one entry per parameter combination, and a
+            # single-entry list for an unparameterized benchmark. Entries
+            # are None where the benchmark failed or was skipped.
+            values = result.get_result_value(name, params)
+            if not params:
+                if values and isinstance(values[0], float):
+                    timings[name] = values[0]
+                continue
+            # asv flattens parameterized results with itertools.product
+            # (see asv/results.py `_compatible_results`), so zipping the
+            # same product is what keeps each value with its own
+            # parameter combination.
+            for combo, value in zip(itertools.product(*params), values):
+                if isinstance(value, float):
+                    timings[f"{name}({', '.join(combo)})"] = value
+    return timings
+
+
+class Verdict(NamedTuple):
+    """How each changed benchmark was classified."""
+
+    blocking: list[Change]
+    reported: list[Change]
+    improved: list[Change]
+
+
+def classify(
+    before: dict[str, float],
+    after: dict[str, float],
+    factor: float,
+    floor: float,
+    report_factor: float,
+) -> Verdict:
+    """Splits changed benchmarks into blocking, reported and improved.
+
+    A benchmark blocks only if it is both slower than ``factor`` and slow
+    enough overall to be measurable (``floor``). Everything that moved by
+    ``report_factor`` either way is still reported, so a microbenchmark
+    regression is visible even though it cannot block.
+    """
+    blocking: list[Change] = []
+    reported: list[Change] = []
+    improved: list[Change] = []
+    # Sorted so the report is stable run to run, not dict-order dependent.
+    for name in sorted(before.keys() & after.keys()):
+        old, new = before[name], after[name]
+        if not old > 0.0:
+            continue
+        change = Change(name, old, new)
+        if change.ratio >= factor and old >= floor:
+            blocking.append(change)
+        elif change.ratio >= report_factor:
+            reported.append(change)
+        elif change.ratio <= 1.0 / report_factor:
+            improved.append(change)
+    return Verdict(blocking, reported, improved)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="asv.conf.json")
+    parser.add_argument("--machine", required=True)
+    parser.add_argument("--base", required=True, help="Base commit hash.")
+    parser.add_argument("--head", required=True, help="Head commit hash.")
+    parser.add_argument(
+        "--factor",
+        type=float,
+        required=True,
+        help="Ratio at or above which a slowdown blocks.",
+    )
+    parser.add_argument(
+        "--report-factor",
+        type=float,
+        required=True,
+        help="Ratio at or above which a movement is reported (never blocks).",
+    )
+    parser.add_argument(
+        "--min-seconds",
+        type=float,
+        required=True,
+        help=(
+            "Baseline runtime a benchmark must reach before it can block. "
+            "Anything faster is reported only."
+        ),
+    )
+    args = parser.parse_args()
+
+    results_dir = Config.load(args.config).results_dir
+    before = load_timings(results_dir, args.machine, args.base)
+    after = load_timings(results_dir, args.machine, args.head)
+    if not before or not after:
+        print(
+            f"::error::No stored results for "
+            f"{'base' if not before else 'head'} on machine "
+            f"{args.machine!r}. Nothing to gate on.",
+            file=sys.stderr,
+        )
+        return 1
+
+    verdict = classify(
+        before, after, args.factor, args.min_seconds, args.report_factor
+    )
+    floor = format_seconds(args.min_seconds)
+
+    if verdict.improved:
+        print("Faster (never blocks):")
+        for change in verdict.improved:
+            print(f"  {change.ratio:>5.2f}  {change.name}")
+    if verdict.reported:
+        print(
+            f"\nMoved, but not blocking (under {args.factor}x, or "
+            f"under the {floor} floor where this runner's noise exceeds "
+            "the factor):"
+        )
+        for change in verdict.reported:
+            print(
+                f"  {change.ratio:>5.2f}  {change.name}  "
+                f"(baseline {format_seconds(change.before)})"
+            )
+    if verdict.blocking:
+        print(
+            f"\n::error::{len(verdict.blocking)} benchmark(s) at or above "
+            f"{floor} regressed by {args.factor}x or more:"
+        )
+        for change in verdict.blocking:
+            print(
+                f"  {change.ratio:>5.2f}  {change.name}  "
+                f"({format_seconds(change.before)} -> "
+                f"{format_seconds(change.after)})"
+            )
+        return 1
+
+    print(
+        f"\nNo benchmark at or above {floor} regressed by "
+        f"{args.factor}x or more ({len(before)} benchmarks compared)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -12,30 +12,40 @@ permissions:
   contents: read
   pull-requests: write
 
-# Two thresholds, declared once so the flags and the prose describing them
-# cannot drift apart.
+# Gate thresholds, declared once so the flags and the prose describing
+# them cannot drift apart.
 #
-# REPORT_FACTOR is what gets shown: every benchmark that moved by 10% or
-# more lands in the PR comment for a human to read.
+# A factor alone does not work on a shared runner. Measured across roughly
+# ten `asv continuous` legs whose `src/` and `benchmarks/` were
+# byte-identical between base and head -- so every flagged result was
+# noise:
 #
-# GATE_FACTOR is what blocks the PR, and it is deliberately looser, because
-# 1.1 is below this runner's noise floor. Measured on six `asv continuous`
-# runs whose `src/` and `benchmarks/` were byte-identical between base and
-# head -- so every flagged result was noise:
-#
-#   1.18  CacheDiskHit.time_cache_disk_get            (429us)
+#   1.29  EvalKernels.time_sharpe_ratio               (16.5us)
+#   1.18  CacheDiskHit.time_cache_disk_get             (429us)
 #   1.17  StoreBuildKernels...from_frame(10, 504)     (1.39ms)
-#   1.11  ModelPrepKernels.time_indicator_values...   (60us)
+#   1.12  IndicatorKernels.time_cross(1000)           (7.25us)
+#   1.11  ModelPrepKernels.time_indicator_values...     (60us)
 #   1.11  ModelTrainPrep.time_train_models_per_symbol (1.92ms)
+#   0.65  CacheDiskHit.time_cache_disk_get             (633us)
 #
-# One in six runs flagged something at 1.1, and every false positive was a
-# sub-2ms microbenchmark; the walkforward macrobenchmarks (100ms and up)
-# never moved. 1.25 clears the observed noise with margin. Raise the
-# sampling (`--attribute rounds=N`) rather than this number if that stops
-# being true -- loosening it further trades away real coverage.
+# Every one is under 2ms, and the same benchmark read 1.12 on one leg and
+# 0.83 on another *in the same run*. The walkforward macrobenchmarks
+# (100ms and up) have never been flagged. A 1.25 gate was tried first and
+# the very next run produced a 1.29 on a 16us benchmark: the noise is a
+# property of how short the benchmark is, so no factor separates signal
+# from noise down there.
+#
+# So the gate needs both axes. GATE_MIN_SECONDS is the baseline runtime a
+# benchmark must reach before it is allowed to block; GATE_FACTOR is the
+# slowdown that blocks once it does. REPORT_FACTOR is purely what gets
+# shown -- everything that moved is reported either way, so a
+# microbenchmark regression stays visible, it just cannot block a PR on a
+# coin flip.
 env:
   REPORT_FACTOR: "1.1"
   GATE_FACTOR: "1.25"
+  GATE_MIN_SECONDS: "0.01"
+
 
 jobs:
   # Matrix comes from .github/python-versions.json, the same source the
@@ -107,7 +117,7 @@ jobs:
           asv continuous "origin/${BASE_REF}" HEAD \
             --python="${PY_VERSION}" \
             --machine "ci-ubuntu-latest-py${PY_VERSION}" \
-            --factor "${GATE_FACTOR}" \
+            --factor "${REPORT_FACTOR}" \
             --interleave-rounds \
             >asv-continuous.log 2>&1
           EXIT=$?
@@ -138,33 +148,27 @@ jobs:
             exit 1
           fi
 
-      # Reads the results the step above already stored -- no benchmark is
-      # re-run, so the reporting threshold costs nothing. Non-fatal: a
-      # missing table must not fail a PR that the gate passed.
-      - name: Compare at the reporting threshold
-        id: compare
+      # Decides the gate from the JSON asv already wrote under
+      # .asv/results/, via asv's own reader -- no rendered table is parsed
+      # and no units are converted, because the stored values are floats
+      # in seconds. Its output doubles as the human-readable report.
+      - name: Decide the gate
+        id: gate
         env:
           BASE_REF: ${{ github.base_ref }}
           PY_VERSION: ${{ matrix.python }}
         run: |
           set +e
-          asv compare "origin/${BASE_REF}" HEAD \
-            --python="${PY_VERSION}" \
+          python .github/scripts/asv_gate.py \
             --machine "ci-ubuntu-latest-py${PY_VERSION}" \
-            --factor "${REPORT_FACTOR}" \
-            --only-changed \
-            >asv-compare.log 2>&1
-          RC=$?
-          if [ "$RC" -ne 0 ]; then
-            echo "" >>asv-compare.log
-            echo "(asv compare exited ${RC}; the table above may be" \
-                 "incomplete. The gate verdict is unaffected.)" \
-              >>asv-compare.log
-          elif [ ! -s asv-compare.log ]; then
-            echo "No benchmark moved by ${REPORT_FACTOR}x or more." \
-              >asv-compare.log
-          fi
-          cat asv-compare.log
+            --base "$(git rev-parse "origin/${BASE_REF}")" \
+            --head "$(git rev-parse HEAD)" \
+            --factor "${GATE_FACTOR}" \
+            --report-factor "${REPORT_FACTOR}" \
+            --min-seconds "${GATE_MIN_SECONDS}" \
+            >asv-gate.log 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat asv-gate.log
           exit 0
 
       - name: Write diff to job summary
@@ -178,10 +182,10 @@ jobs:
             echo ""
             echo "Exit code: $ASV_EXIT (1 = flagged regression at --factor ${GATE_FACTOR}; 2 = a benchmark raised, nothing compared)"
             echo ""
-            echo "### Moved by ${REPORT_FACTOR}x or more"
+            echo "### Gate"
             echo ""
             echo '```'
-            cat asv-compare.log
+            cat asv-gate.log
             echo '```'
             echo ""
             echo "### Full run"
@@ -202,10 +206,10 @@ jobs:
             echo ""
             echo "Exit code: \`$ASV_EXIT\` (\`1\` = flagged regression at \`--factor ${GATE_FACTOR}\`; \`2\` = a benchmark raised, so nothing was compared)"
             echo ""
-            echo "**Moved by ${REPORT_FACTOR}x or more** — reported, not blocking:"
+            echo "**Gate** — blocks only at or above \`${GATE_MIN_SECONDS}s\`, where this runner can measure reliably:"
             echo ""
             echo '```'
-            cat asv-compare.log
+            cat asv-gate.log
             echo '```'
             echo ""
             echo "<details>"
@@ -222,7 +226,7 @@ jobs:
             elif [ "$ASV_EXIT" != "0" ] && [ "$OVERRIDE" = "true" ]; then
               echo "_Gate forced green by \`bench-override\` label._"
             else
-              echo "_Blocking at \`--factor ${GATE_FACTOR}\`, reporting from \`--factor ${REPORT_FACTOR}\`: 1.1 sits below this runner's noise floor, where identical code has flagged sub-2ms microbenchmarks at up to 1.18. Override via the \`bench-override\` PR label. For the trend view, run \`asv publish && asv preview\` locally against committed \`.asv/results/\`._"
+              echo "_Blocks only when a benchmark of at least \`${GATE_MIN_SECONDS}s\` regresses by \`${GATE_FACTOR}x\`. Shorter benchmarks are reported, never blocking: on this runner, identical code has produced ratios from 0.65 to 1.29 on sub-2ms benchmarks. Override via the \`bench-override\` PR label._"
             fi
           } > sticky-comment.md
 
@@ -241,23 +245,18 @@ jobs:
       - name: Enforce regression gate
         env:
           ASV_EXIT: ${{ steps.continuous.outputs.exit_code }}
+          GATE_EXIT: ${{ steps.gate.outputs.exit_code }}
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'bench-override') }}
           PY_VERSION: ${{ matrix.python }}
         run: |
-          if [ "$ASV_EXIT" = "0" ]; then
-            echo "No regression flagged at ${GATE_FACTOR}x on Python ${PY_VERSION}."
-            exit 0
-          fi
-          # asv distinguishes the two non-zero exits and the gate must too.
-          # `asv run` returns 2 when any benchmark raised, and `asv
-          # continuous` propagates that immediately -- before it compares
-          # anything -- so exit 2 means "a benchmark is broken", not "this PR
-          # is slower". Reporting it as a regression is the same conflation
-          # that made a config drift look like one.
+          # `asv run` returns 2 when a benchmark raised, and `asv
+          # continuous` propagates that before comparing anything -- so
+          # exit 2 means "a benchmark is broken", not "this PR is slower".
+          # Reporting it as a regression is the same conflation that made a
+          # config drift look like one.
           #
-          # bench-override deliberately does not apply here: it exists to
-          # accept a measured slowdown, not to merge a benchmark that cannot
-          # run.
+          # bench-override deliberately does not apply: it exists to accept
+          # a measured slowdown, not to merge a benchmark that cannot run.
           if [ "$ASV_EXIT" = "2" ]; then
             echo "::error::asv exited 2 -- at least one benchmark raised an" \
                  "exception, so nothing was compared. This is not a" \
@@ -265,9 +264,16 @@ jobs:
             grep -nE "failed" asv-continuous.log | head -20
             exit 1
           fi
-          if [ "$OVERRIDE" = "true" ]; then
-            echo "Regression flagged (exit $ASV_EXIT) but 'bench-override' label is set — forcing green."
+          # Everything else is decided by asv_gate.py, not by asv's own
+          # exit code: asv flags on factor alone, which is what produced
+          # the false positives above.
+          if [ "$GATE_EXIT" = "0" ]; then
+            echo "No benchmark at or above ${GATE_MIN_SECONDS}s regressed by ${GATE_FACTOR}x on Python ${PY_VERSION}."
             exit 0
           fi
-          echo "Regression flagged (exit $ASV_EXIT) and no 'bench-override' label — failing the gate."
-          exit "$ASV_EXIT"
+          if [ "$OVERRIDE" = "true" ]; then
+            echo "Regression flagged but 'bench-override' label is set — forcing green."
+            exit 0
+          fi
+          echo "Regression flagged and no 'bench-override' label — failing the gate."
+          exit 1


### PR DESCRIPTION
**Draft — stacked on #289.** Until that merges this diff also shows its commit; I rebase once it lands. Please take #289 first, it restores a gate that is currently down.

## The problem

`--factor` alone cannot work on a shared runner. Across roughly ten `asv continuous` legs whose `src/` and `benchmarks/` were **byte-identical** between base and head — so every flagged result was noise:

| ratio | benchmark | baseline |
|---|---|---|
| 1.29 | `EvalKernels.time_sharpe_ratio` | 16.5 µs |
| 1.18 | `CacheDiskHit.time_cache_disk_get` | 429 µs |
| 1.17 | `StoreBuildKernels…from_frame(10, 504)` | 1.39 ms |
| 1.12 | `IndicatorKernels.time_cross(1000)` | 7.25 µs |
| 1.11 | `ModelPrepKernels.time_indicator_values…` | 60 µs |
| 1.11 | `ModelTrainPrep.time_train_models_per_symbol` | 1.92 ms |
| 0.65 | `CacheDiskHit.time_cache_disk_get` | 633 µs |

Every one is under 2 ms. The same benchmark read **1.12 on one leg and 0.83 on another in the same run**. The walkforward macrobenchmarks (100 ms and up) have never been flagged, across every run.

I tried a plain 1.25 gate first, on the evidence available then. The very next run produced a **1.29 on a 16 µs benchmark**. The noise is a property of how short the benchmark is, not of the threshold — raising the factor only trades false positives for blindness.

## The change

A benchmark blocks only when it is **slow enough to measure** *and* it regressed past the factor:

```yaml
REPORT_FACTOR: "1.1"      # shown
GATE_FACTOR:   "1.25"     # blocks, once...
GATE_MIN_SECONDS: "0.01"  # ...the baseline is at least this long
```

Everything that moved is still reported either way, so a microbenchmark regression stays visible to a reviewer — it just cannot block a PR on a coin flip.

## No table parsing

The decision reads the JSON asv already writes under `.asv/results/`, through asv's own `asv.results` API. Values arrive as floats in seconds, so nothing parses a rendered table and no units are converted.

Worth saying: the first cut of this *did* parse `asv compare`'s ASCII table, and its unit regex silently read `16.5±0.3μs` as **16.5 seconds** — the error-bar group absorbed the `μ` and left `s` as the unit, inverting the duration floor. That is the argument for reading the JSON, and it is why the script has no regex in it now.

Because the script's output is the report, the separate `asv compare` step is gone — one mechanism instead of two.

## Verification

Against fixtures written by **asv's own writer** (`Results.add_result` / `.save`), so the format is asv's rather than my guess at it. The corpus covers unparameterized and parameterized benchmarks, micro and macro, an improvement, an unchanged benchmark, and the 10 ms boundary:

```
Faster (never blocks):
   0.65  CacheDiskHit.time_cache_disk_get
Moved, but not blocking (under 1.25x, or under the 10ms floor…):
   1.29  EvalKernels.time_sharpe_ratio             (baseline 16.5us)
   1.18  StoreBuild.time_from_frame(12, 504)       (baseline 1.39ms)
::error::2 benchmark(s) at or above 10ms regressed by 1.25x or more:
   1.60  Scaled.time_scaled(10)                    (500ms -> 800ms)
   1.42  time_walkforward_volume                   (239ms -> 340ms)
```

The 1.29 that broke the previous gate is reported and does not block; a genuine 239 ms → 340 ms macro regression still does. Parameter combinations are zipped through `itertools.product`, matching how asv flattens them (`asv/results.py`), so a regression is attributed to the right combination — the fixture injects one on index 3 of a 2×2 and it is reported as `(12, 504)`.

## Live result on this PR

This PR's own three legs, comparing the same commit pair, on code that touches only CI files:

| leg | `CacheDiskHit.time_cache_disk_get` | verdict |
|---|---|---|
| 3.11 | **1.45** (baseline 406 µs) | reported, not blocking |
| 3.12 | 0.90 | faster |
| 3.13 | 0.76 | faster |

A **1.9× spread on identical code**, between legs of one run. Under the previous factor-only gate the 3.11 leg would have blocked this PR at 1.45 — a worse false positive than any measured before. All three legs passed here, 73 benchmarks compared each, no macrobenchmark regression.

## Open question for you

The 10 ms floor is empirical, not principled: it sits above every false positive observed and below every macrobenchmark. If you would rather not have a blocking gate at all, deleting the script and reporting only is a smaller change and I am happy to send that instead — the measurements above are the useful part either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
