### PR TITLE
perf: keep the IntervalContext cache across bars

### DIFF
--- a/src/pybroker/context.py
+++ b/src/pybroker/context.py
@@ -1757,8 +1757,16 @@ def set_exec_ctx_data(ctx: ExecContext, date: np.datetime64):
     """
     ctx._curr_date = date
     ctx._dt = None
+    # ``_foreign`` holds :class:`pybroker.common.BarData` built from arrays
+    # that were already sliced to the bar it was fetched on, so it cannot
+    # survive into the next one.
+    #
+    # ``_interval`` is deliberately not cleared. An :class:`.IntervalContext`
+    # holds only window-constant references and reads the shared
+    # ``sym_end_index`` on every property, so a cached one reports the current
+    # bar rather than the bar it was built on. Clearing it rebuilt an
+    # identical object on every bar of every symbol that reads an interval.
     ctx._foreign.clear()
-    ctx._interval.clear()
     ctx._cover = False
     ctx._exiting_pos = False
     ctx._exit_stop_pos = None

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -5932,6 +5932,41 @@ class TestStrategyIntervals:
         for n_bars, _close, n_ind in seen:
             assert n_ind == n_bars
 
+    def test_interval_context_is_a_live_view_not_a_snapshot(
+        self, data_source_df, scope
+    ):
+        """An :class:`.IntervalContext` must report the *current* bar.
+
+        It holds the shared ``sym_end_index`` and reads it on every property,
+        so one obtained on an early bar still answers for a later bar. That is
+        the invariant which lets ``set_exec_ctx_data`` keep ``ctx._interval``
+        across bars instead of rebuilding an identical object every time.
+
+        The existing interval tests all pass against a version that snapshots
+        the index at construction, so without this the invariant is unguarded.
+        """
+        held = {}
+        observed = []
+
+        def exec_fn(ctx):
+            weekly = ctx.interval("weekly")
+            if "ctx" not in held and len(weekly.close) > 0:
+                # Keep the instance from this bar and never re-fetch it.
+                held["ctx"] = weekly
+            if "ctx" in held:
+                observed.append(len(held["ctx"].close))
+
+        strategy = Strategy(data_source_df, START_DATE, END_DATE)
+        strategy.add_execution(exec_fn, "SPY", intervals=["weekly"])
+        strategy.walkforward(windows=1, timeframe="1d")
+
+        assert observed
+        assert observed[-1] > observed[0], (
+            "IntervalContext snapshotted its bar index instead of reading it "
+            "live, so a held instance reported a stale bar."
+        )
+        assert observed == sorted(observed)
+
     def test_undeclared_interval_then_error(self, data_source_df, scope):
         def exec_fn(ctx):
             ctx.interval("weekly")


### PR DESCRIPTION
`set_exec_ctx_data` clears `ctx._interval` on every bar, so every symbol that reads an interval rebuilds an `IntervalContext` on every bar of the run — and the rebuilt object is identical to the one just discarded.

`IntervalContext` stores six references, all window-constant, and every property reads the shared `sym_end_index` live:

```python
@property
def bars(self) -> int:
    end_index = self._sym_end_index[self._symbol]
    ...
```

So a cached instance answers for the *current* bar, not the bar it was built on. Nothing about it is per-bar state.

`ctx._foreign` is still cleared — that one holds `BarData` built from arrays already sliced to the bar it was fetched on, and genuinely must not survive.

## The test is the point

This turns an incidental property of `IntervalContext` into a load-bearing one, and nothing currently guards it. I broke `IntervalContext` so it snapshots `sym_end_index` at construction — exactly the regression that would make the cache unsafe — and:

| | result |
|---|---|
| the 69 existing interval tests | **all passed** |
| the new test | **failed**, naming the cause |

So the change ships with `test_interval_context_is_a_live_view_not_a_snapshot`, which holds an `IntervalContext` from an early bar and asserts it reports advancing lengths later. Without it, a future change adding per-bar state to `IntervalContext` would silently reintroduce stale reads.

## Measurement — offered as a waste fix, not an optimization

Idle 8-core box, Python 3.14, paired interleaved reps against `dev`, median paired ratio:

| scenario | ratio | reps won |
|---|---|---|
| 10 syms × 504 days × 3 windows, one interval read per bar | 1.036× | 9/9 |
| same, three intervals read per bar | 1.091× | 9/9 |
| `large` / `wide` controls, no intervals declared | 1.004× / 1.017× | 15 reps |

The first row mirrors `WalkforwardIntervals`, the only asv benchmark on this path. **That is below the 1.1× reporting threshold**, so I'd expect CI to show nothing — which is why this is framed as removing pointless work rather than as a speedup. The gain is confined to strategies that declare and read intervals; where `ctx._interval` stays empty there is nothing to save, which is every other asv scenario.

## Verification

- Byte-identical order and trade streams on integer-share, fractional-share and percentage-fee scenarios
- Zero trajectory divergences across a 15-run seed sweep (~13k orders)
- Full suite: 5,178 passed on Python 3.14 (5,177 + the new test)
- `ruff format`, `ruff check`, `mypy`, and `sphinx-build -n -W --keep-going` all clean

Draft until you've had a look.
