### PR TITLE
perf: add opt-in fast_marking for float64 position marking

### DIFF
--- a/benchmarks/bench_backtest.py
+++ b/benchmarks/bench_backtest.py
@@ -1709,3 +1709,64 @@ class WalkforwardModelsPerSymbol:
             indicators=[hhv20],
         )
         return strategy
+
+
+def _build_pyramid_strategy(df: pd.DataFrame, fast_marking: bool) -> Strategy:
+    """Adds to every position on every up-bar and never trims.
+
+    Pyramiding is the shape ``fast_marking`` exists for: the compiled mark
+    kernel amortizes its dispatch cost over a position's entries, so a
+    portfolio of single-entry positions sees no benefit while one that
+    accumulates entries does.
+    """
+    pybroker.clear_params()
+    pybroker.disable_logging()
+    pybroker.disable_progress_bar()
+
+    def exec_fn(ctx: ExecContext) -> None:
+        if ctx.bars < 20:
+            return
+        if ctx.close[-1] > ctx.close[-2]:
+            ctx.buy_shares = ctx.calc_target_shares(0.004)
+
+    start = df["date"].min().strftime("%Y-%m-%d")
+    end = df["date"].max().strftime("%Y-%m-%d")
+    strategy = Strategy(
+        df,
+        start,
+        end,
+        StrategyConfig(
+            initial_cash=2_000_000,
+            fast_marking=fast_marking,
+            exit_on_last_bar=True,
+        ),
+    )
+    strategy.add_execution(
+        exec_fn,
+        symbols=sorted(df["symbol"].unique().tolist()),
+    )
+    return strategy
+
+
+class PortfolioFastMarking:
+    """Marking cost with pyramided positions, exact vs compiled float64.
+
+    Parametrized on ``fast_marking`` so a regression in either path shows up
+    on its own, rather than the two being averaged into one number.
+    """
+
+    timeout = 600
+    params = [False, True]
+    param_names = ["fast_marking"]
+
+    def setup(self, fast_marking: bool) -> None:
+        np.random.seed(SEED)
+        self.df = _synthetic_ohlcv(n_symbols=20, n_days=252 * 2, seed=SEED)
+        _build_pyramid_strategy(self.df, fast_marking).backtest(
+            calc_bootstrap=False
+        )
+
+    def time_pyramid_marking(self, fast_marking: bool) -> None:
+        _build_pyramid_strategy(self.df, fast_marking).backtest(
+            calc_bootstrap=False
+        )

--- a/benchmarks/bench_backtest.py
+++ b/benchmarks/bench_backtest.py
@@ -12,6 +12,7 @@ invocation pays Numba JIT compile cost — useful for tracking the benefit of
 
 from __future__ import annotations
 
+import dataclasses
 import sys
 import zlib
 from pathlib import Path
@@ -1731,16 +1732,16 @@ def _build_pyramid_strategy(df: pd.DataFrame, fast_marking: bool) -> Strategy:
 
     start = df["date"].min().strftime("%Y-%m-%d")
     end = df["date"].max().strftime("%Y-%m-%d")
-    strategy = Strategy(
-        df,
-        start,
-        end,
-        StrategyConfig(
-            initial_cash=2_000_000,
-            fast_marking=fast_marking,
-            exit_on_last_bar=True,
-        ),
-    )
+    config_kwargs = {
+        "initial_cash": 2_000_000,
+        "exit_on_last_bar": True,
+    }
+    # asv continuous runs this file against the PR's base commit too, which
+    # may predate fast_marking; omit it there rather than crash, so both
+    # parametrizations fall back to the same (only) available code path.
+    if "fast_marking" in {f.name for f in dataclasses.fields(StrategyConfig)}:
+        config_kwargs["fast_marking"] = fast_marking
+    strategy = Strategy(df, start, end, StrategyConfig(**config_kwargs))
     strategy.add_execution(
         exec_fn,
         symbols=sorted(df["symbol"].unique().tolist()),

--- a/docs/source/reference/pybroker.config.rst
+++ b/docs/source/reference/pybroker.config.rst
@@ -10,4 +10,4 @@ pybroker.config module
       enable_fractional_shares, exit_on_last_bar, exit_cover_fill_price,
       exit_sell_fill_price, bars_per_year, return_signals, round_test_result,
       round_fill_price, return_stops, position_mode, leverage, interest_rate,
-      record_portfolio_bars, record_position_bars
+      record_portfolio_bars, record_position_bars, fast_marking

--- a/src/pybroker/config.py
+++ b/src/pybroker/config.py
@@ -92,6 +92,14 @@ class StrategyConfig:
             :attr:`pybroker.portfolio.Portfolio.position_bars` on every bar.
             When ``False`` (default), :attr:`pybroker.strategy.TestResult.positions`
             is empty.
+        fast_marking: When ``True``, mark open positions with a compiled
+            float64 kernel instead of exact :class:`decimal.Decimal`
+            arithmetic. Unrealized PnL and MAE/MFE can then differ from the
+            exact path in the last ulp -- far below the cent rounding applied
+            to :class:`pybroker.strategy.TestResult` -- in exchange for a
+            faster bar loop on portfolios holding many positions. Cash, fees,
+            realized PnL, share counts and order sizing are unaffected and
+            stay exact. Defaults to ``False``.
     """
 
     initial_cash: float = field(default=100_000)
@@ -122,3 +130,4 @@ class StrategyConfig:
     interest_rate: float = field(default=0.0)
     record_portfolio_bars: bool = field(default=False)
     record_position_bars: bool = field(default=False)
+    fast_marking: bool = field(default=False)

--- a/src/pybroker/portfolio.py
+++ b/src/pybroker/portfolio.py
@@ -11,6 +11,8 @@ This code is licensed under Apache 2.0 with Commons Clause license
 import itertools
 import math
 import numpy as np
+from numba import njit
+from numpy.typing import NDArray
 from pybroker.common import (
     BarData,
     DataCol,
@@ -73,6 +75,11 @@ _COL_CLOSE: Final = DataCol.CLOSE.value
 _COL_LOW: Final = DataCol.LOW.value
 _COL_HIGH: Final = DataCol.HIGH.value
 _CAPTURE_BAR_COLS: Final = (_COL_DATE, _COL_CLOSE, _COL_LOW, _COL_HIGH)
+
+# Shared zero-length defaults for Position's float64 entry mirror. See the
+# fields on Position for why sharing a mutable default is safe here.
+_EMPTY_F64: Final[NDArray[np.float64]] = np.empty(0, dtype=np.float64)
+_EMPTY_I64: Final[NDArray[np.int64]] = np.empty(0, dtype=np.int64)
 
 
 class Stop(NamedTuple):
@@ -232,6 +239,36 @@ class Position:
     entry_notional: Decimal = field(default_factory=Decimal)
     unmarked_shares: Decimal = field(default_factory=Decimal)
     unmarked_notional: Decimal = field(default_factory=Decimal)
+    # float64 mirror of ``entries`` used only when fast marking is enabled.
+    # Kept out of repr and equality so Position's public surface is unchanged.
+    # ``entries`` stays authoritative: these are rebuilt from it whenever the
+    # entry list changes, so nothing here needs syncing back.
+    #
+    # The zero-length defaults are shared module constants rather than
+    # per-Position allocations, so a portfolio that never enables fast marking
+    # pays nothing for them. Sharing is safe because _mark_cap starts at 0, so
+    # the first rebuild always replaces them before anything is written.
+    _mark_price: NDArray[np.float64] = field(
+        default_factory=lambda: _EMPTY_F64, repr=False, compare=False
+    )
+    _mark_shares: NDArray[np.float64] = field(
+        default_factory=lambda: _EMPTY_F64, repr=False, compare=False
+    )
+    _mark_mae: NDArray[np.float64] = field(
+        default_factory=lambda: _EMPTY_F64, repr=False, compare=False
+    )
+    _mark_mfe: NDArray[np.float64] = field(
+        default_factory=lambda: _EMPTY_F64, repr=False, compare=False
+    )
+    _mark_mae_idx: NDArray[np.int64] = field(
+        default_factory=lambda: _EMPTY_I64, repr=False, compare=False
+    )
+    _mark_mfe_idx: NDArray[np.int64] = field(
+        default_factory=lambda: _EMPTY_I64, repr=False, compare=False
+    )
+    _mark_n: int = field(default=0, repr=False, compare=False)
+    _mark_cap: int = field(default=0, repr=False, compare=False)
+    _mark_stale: bool = field(default=True, repr=False, compare=False)
 
     def _marked_value(self) -> Decimal:
         """Returns the position's value at the last mark.
@@ -480,6 +517,152 @@ def _calculate_pnl_mae_mfe(
     pos.pnl = pnl
 
 
+class _MarkResult(NamedTuple):
+    """Result of :func:`._mark_entries_njit`.
+
+    Attributes:
+        pnl: Unrealized PnL summed over the marked entries.
+        mae_count: Number of leading entries in ``mae_idx`` that took a new
+            maximum adverse excursion on this bar.
+        mfe_count: Number of leading entries in ``mfe_idx`` that took a new
+            maximum favorable excursion on this bar.
+    """
+
+    pnl: float
+    mae_count: int
+    mfe_count: int
+
+
+@njit(cache=True)
+def _mark_entries_njit(
+    prices: NDArray[np.float64],
+    shares: NDArray[np.float64],
+    mae: NDArray[np.float64],
+    mfe: NDArray[np.float64],
+    mae_idx: NDArray[np.int64],
+    mfe_idx: NDArray[np.int64],
+    count: int,
+    close: float,
+    loss_ref: float,
+    profit_ref: float,
+    has_loss: bool,
+    has_profit: bool,
+    is_long: bool,
+) -> _MarkResult:
+    """Marks ``count`` entries against one bar in float64.
+
+    ``mae``/``mfe`` are updated in place, and the indices of entries that took
+    a new extreme are written to ``mae_idx``/``mfe_idx`` so the caller can
+    materialize only those back onto :class:`.Entry`. New extremes are rare
+    after the opening bars, which is what keeps that write-back cheap.
+
+    ``loss_ref`` and ``profit_ref`` are the bar's low/high for a long position
+    and high/low for a short, resolved by the caller so this stays branch-free
+    on position type beyond the sign of the PnL term.
+
+    Bounds are not checked: the caller owns these arrays and passes their fill
+    count, per the validate-outside-index-inside rule.
+    """
+    pnl = 0.0
+    mae_count = 0
+    mfe_count = 0
+    for i in range(count):
+        price = prices[i]
+        if is_long:
+            pnl += (close - price) * shares[i]
+            loss = loss_ref - price
+            profit = profit_ref - price
+        else:
+            pnl += (price - close) * shares[i]
+            loss = price - loss_ref
+            profit = price - profit_ref
+        # NaN never compares true, so a halted bar's NaN low/high leaves the
+        # stored extreme untouched -- matching the Decimal path, where the
+        # same comparison against a NaN difference is also False.
+        if has_loss and loss < 0 and loss < mae[i]:
+            mae[i] = loss
+            mae_idx[mae_count] = i
+            mae_count += 1
+        if has_profit and profit > 0 and profit > mfe[i]:
+            mfe[i] = profit
+            mfe_idx[mfe_count] = i
+            mfe_count += 1
+    return _MarkResult(pnl, mae_count, mfe_count)
+
+
+def _entry_marks(pos: Position):
+    """Returns ``pos``'s float64 entry mirror, rebuilding it when stale.
+
+    Rebuilt from :attr:`.Position.entries`, which stays the source of truth --
+    so a rebuild can never lose an extreme, and no state has to be written
+    back to the entries when the list changes.
+    """
+    count = len(pos.entries)
+    if pos._mark_stale or count != pos._mark_n:
+        if count > pos._mark_cap:
+            cap = max(8, count * 2)
+            pos._mark_price = np.empty(cap, dtype=np.float64)
+            pos._mark_shares = np.empty(cap, dtype=np.float64)
+            pos._mark_mae = np.empty(cap, dtype=np.float64)
+            pos._mark_mfe = np.empty(cap, dtype=np.float64)
+            pos._mark_mae_idx = np.empty(cap, dtype=np.int64)
+            pos._mark_mfe_idx = np.empty(cap, dtype=np.int64)
+            pos._mark_cap = cap
+        for i, entry in enumerate(pos.entries):
+            pos._mark_price[i] = float(entry.price)
+            pos._mark_shares[i] = float(entry.shares)
+            pos._mark_mae[i] = float(entry.mae)
+            pos._mark_mfe[i] = float(entry.mfe)
+        pos._mark_n = count
+        pos._mark_stale = False
+
+
+def _calculate_pnl_mae_mfe_fast(
+    pos: Position,
+    close: float,
+    low: Optional[float],
+    high: Optional[float],
+):
+    """float64 counterpart of :func:`._calculate_pnl_mae_mfe`.
+
+    Computes the same quantities with float64 arithmetic in a compiled kernel
+    instead of exact :class:`decimal.Decimal` arithmetic. Values can differ
+    from the exact path in the last ulp, which is far below the cent
+    quantization applied when results reach :class:`pybroker.strategy.TestResult`.
+    Selected by ``fast_marking``; the exact path remains the default.
+    """
+    if pos.type != "long" and pos.type != "short":
+        raise ValueError(f"Unknown position type: {pos.type}")
+    _entry_marks(pos)
+    is_long = pos.type == "long"
+    loss_ref = low if is_long else high
+    profit_ref = high if is_long else low
+    result = _mark_entries_njit(
+        pos._mark_price,
+        pos._mark_shares,
+        pos._mark_mae,
+        pos._mark_mfe,
+        pos._mark_mae_idx,
+        pos._mark_mfe_idx,
+        pos._mark_n,
+        close,
+        0.0 if loss_ref is None else loss_ref,
+        0.0 if profit_ref is None else profit_ref,
+        loss_ref is not None,
+        profit_ref is not None,
+        is_long,
+    )
+    if result.mae_count or result.mfe_count:
+        entries = pos.entries
+        for k in range(result.mae_count):
+            i = int(pos._mark_mae_idx[k])
+            entries[i].mae = to_decimal(pos._mark_mae[i])
+        for k in range(result.mfe_count):
+            i = int(pos._mark_mfe_idx[k])
+            entries[i].mfe = to_decimal(pos._mark_mfe[i])
+    pos.pnl = to_decimal(result.pnl)
+
+
 class Portfolio:
     r"""Class representing a portfolio of holdings. The portfolio contains
     information about open positions and balances, and is also used to place
@@ -496,6 +679,11 @@ class Portfolio:
         max_short_positions: Maximum number of short :class:`.Position`\ s that
             can be held at a time. If ``None``, then unlimited.
         record_stops: Whether to record stop data per-bar.
+        fast_marking: Whether to mark open positions with a compiled float64
+            kernel instead of exact :class:`decimal.Decimal` arithmetic.
+            Unrealized PnL and MAE/MFE may then differ in the last ulp, which
+            is far below the cent rounding applied to results. Cash, fees,
+            realized PnL and share counts stay exact either way.
 
     Attributes:
         cash: Current cash balance.
@@ -545,6 +733,7 @@ class Portfolio:
         bars_per_year: Optional[int] = None,
         record_portfolio_bars: bool = False,
         record_position_bars: bool = False,
+        fast_marking: bool = False,
     ):
         self.cash: Decimal = to_decimal(cash)
         self._initial_market_value = self.cash
@@ -562,6 +751,7 @@ class Portfolio:
         self._record_stops = record_stops
         self._record_portfolio_bars = record_portfolio_bars
         self._record_position_bars = record_position_bars
+        self._fast_marking = fast_marking
         self._leverage = leverage
         self._interest_rate = interest_rate
         self._bars_per_year = bars_per_year
@@ -680,6 +870,7 @@ class Portfolio:
             date=date,
             type=type,
         )
+        pos._mark_stale = True
         pos.entries.append(entry)
         return entry
 
@@ -1089,6 +1280,7 @@ class Portfolio:
         self.pnl += entry_pnl
         self._release_collateral(entry_amount, entry_pnl)
         pos.shares -= shares
+        pos._mark_stale = True
         entry.shares -= shares
         pos.entry_notional -= entry_amount
         self._short_entry_notional -= entry_amount
@@ -1297,6 +1489,7 @@ class Portfolio:
         self.pnl += entry_pnl
         self._release_collateral(entry_amount, entry_pnl)
         pos.shares -= shares
+        pos._mark_stale = True
         entry.shares -= shares
         pos.entry_notional -= entry_amount
         self._long_entry_notional -= entry_amount
@@ -1532,9 +1725,20 @@ class Portfolio:
             if sym in self.long_positions:
                 pos = self.long_positions[sym]
                 if close_d is not None:
-                    _calculate_pnl_mae_mfe(
-                        pos, close_d, low=low_f, high=high_f
-                    )
+                    if self._fast_marking:
+                        # close_d is the converted close_f, so the two are
+                        # None together and this branch implies close_f is a
+                        # float; mypy cannot narrow through that.
+                        _calculate_pnl_mae_mfe_fast(
+                            pos,
+                            close_f,  # type: ignore[arg-type]
+                            low_f,
+                            high_f,
+                        )
+                    else:
+                        _calculate_pnl_mae_mfe(
+                            pos, close_d, low=low_f, high=high_f
+                        )
                     pos.equity = pos.shares * close_d
                     pos.market_value = pos.equity
                     pos.close = close_d
@@ -1565,9 +1769,20 @@ class Portfolio:
                 # marks it to market with the position's unrealized PnL.
                 equity_parts.append(float(entry_notional))
                 if close_d is not None:
-                    _calculate_pnl_mae_mfe(
-                        pos, close_d, low=low_f, high=high_f
-                    )
+                    if self._fast_marking:
+                        # close_d is the converted close_f, so the two are
+                        # None together and this branch implies close_f is a
+                        # float; mypy cannot narrow through that.
+                        _calculate_pnl_mae_mfe_fast(
+                            pos,
+                            close_f,  # type: ignore[arg-type]
+                            low_f,
+                            high_f,
+                        )
+                    else:
+                        _calculate_pnl_mae_mfe(
+                            pos, close_d, low=low_f, high=high_f
+                        )
                     pos.close = close_d
                     pos.margin = close_d * pos.shares
                     pos.market_value = pos.margin + pos.pnl

--- a/src/pybroker/strategy.py
+++ b/src/pybroker/strategy.py
@@ -2832,6 +2832,7 @@ class Strategy(
                     effective_config.bars_per_year,
                     record_portfolio_bars=effective_config.record_portfolio_bars,
                     record_position_bars=effective_config.record_position_bars,
+                    fast_marking=effective_config.fast_marking,
                 )
             signals = self._run_walkforward(
                 portfolio=portfolio,

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -26,7 +26,9 @@ from pybroker.portfolio import (
     Position,
     Stop,
     _calculate_pnl_mae_mfe,
+    _calculate_pnl_mae_mfe_fast,
 )
+from pybroker.config import StrategyConfig
 from pybroker.scope import ColumnScope, PriceScope
 from pybroker.slippage import FixedSlippageModel, SlippageModel
 
@@ -4931,3 +4933,109 @@ def test_capture_bar_when_hedged_long_and_short_same_symbol():
     assert bar.long_shares == 100
     assert bar.short_shares == 50
     assert str(bar.close) == str(close_price)
+
+
+@pytest.mark.parametrize("pos_type", ["long", "short"])
+@pytest.mark.parametrize("n_entries", [1, 2, 7])
+def test_fast_marking_agrees_with_exact_path(pos_type, n_entries):
+    """The float64 kernel must agree with exact Decimal marking.
+
+    Not bit-identical by construction -- that is the trade ``fast_marking``
+    makes -- so this pins the contract that actually matters: the two paths
+    agree far inside the cent rounding applied to results.
+    """
+    rng = np.random.default_rng(7)
+    prices = [
+        float(np.round(rng.uniform(1.0, 300.0), 4)) for _ in range(n_entries)
+    ]
+    shares = [
+        float(np.round(rng.uniform(1.0, 500.0), 2)) for _ in range(n_entries)
+    ]
+    pos_exact = _make_mae_mfe_pos(pos_type, prices, shares)
+    pos_fast = _make_mae_mfe_pos(pos_type, prices, shares)
+    for _ in range(200):
+        close = float(np.round(rng.uniform(1.0, 300.0), 4))
+        low = None if rng.random() < 0.15 else close * 0.97
+        high = None if rng.random() < 0.15 else close * 1.03
+        _calculate_pnl_mae_mfe(
+            pos_exact, to_decimal(close), low=low, high=high
+        )
+        _calculate_pnl_mae_mfe_fast(pos_fast, close, low, high)
+        assert float(pos_fast.pnl) == pytest.approx(
+            float(pos_exact.pnl), rel=1e-12
+        )
+        for entry_exact, entry_fast in zip(
+            pos_exact.entries, pos_fast.entries
+        ):
+            assert float(entry_fast.mae) == pytest.approx(
+                float(entry_exact.mae), rel=1e-12, abs=1e-12
+            )
+            assert float(entry_fast.mfe) == pytest.approx(
+                float(entry_exact.mfe), rel=1e-12, abs=1e-12
+            )
+
+
+@pytest.mark.parametrize("pos_type", ["long", "short"])
+def test_fast_marking_rebuilds_when_entries_change(pos_type):
+    """A structural change to entries must invalidate the float64 mirror.
+
+    Appending, partially exiting and removing all mutate the entry list
+    between marks; a stale mirror would silently mark the wrong shares or
+    drop an entry's accumulated extreme.
+    """
+    pos = Position(symbol=SYMBOL_1, shares=Decimal(), type=pos_type)
+    ref = Position(symbol=SYMBOL_1, shares=Decimal(), type=pos_type)
+
+    def add(entry_id, price, qty):
+        for target in (pos, ref):
+            target.entries.append(
+                Entry(
+                    id=entry_id,
+                    date=DATE_1,
+                    symbol=SYMBOL_1,
+                    shares=to_decimal(qty),
+                    price=to_decimal(price),
+                    type=pos_type,
+                )
+            )
+            target.shares += to_decimal(qty)
+        pos._mark_stale = True
+
+    def mark(close):
+        _calculate_pnl_mae_mfe_fast(pos, close, close * 0.98, close * 1.02)
+        _calculate_pnl_mae_mfe(
+            ref, to_decimal(close), low=close * 0.98, high=close * 1.02
+        )
+        assert float(pos.pnl) == pytest.approx(float(ref.pnl), rel=1e-12)
+        for a, b in zip(pos.entries, ref.entries):
+            assert float(a.mae) == pytest.approx(float(b.mae), abs=1e-12)
+            assert float(a.mfe) == pytest.approx(float(b.mfe), abs=1e-12)
+
+    add(1, 50.0, 100)
+    mark(52.0)
+    add(2, 55.0, 40)
+    mark(48.0)
+    # Partial exit: shares change without the entry list changing length.
+    pos.entries[0].shares -= Decimal(30)
+    ref.entries[0].shares -= Decimal(30)
+    pos._mark_stale = True
+    mark(60.0)
+    # Full removal of the oldest entry.
+    pos.entries.popleft()
+    ref.entries.popleft()
+    mark(45.0)
+
+
+def test_fast_marking_defaults_off():
+    """The exact Decimal path stays the default everywhere."""
+    assert StrategyConfig().fast_marking is False
+    assert Portfolio(100_000)._fast_marking is False
+
+
+def test_fast_marking_handles_missing_low_high():
+    """A bar with no low/high must leave the stored extremes untouched."""
+    pos = _make_mae_mfe_pos("long", [50.0], [100.0])
+    _calculate_pnl_mae_mfe_fast(pos, 60.0, None, None)
+    assert pos.entries[0].mae == Decimal()
+    assert pos.entries[0].mfe == Decimal()
+    assert float(pos.pnl) == pytest.approx(1000.0)


### PR DESCRIPTION
`_calculate_pnl_mae_mfe` walks a position's entries every bar doing exact
Decimal arithmetic. Under a new `StrategyConfig.fast_marking` (default
`False`) the same quantities are computed by an `@njit(cache=True)` kernel
over a float64 mirror of the entries instead.

### Deliberately narrow

Only the per-entry marking arithmetic moves to float. Cash, fees, realized
PnL, `Entry.shares`, `Position.shares` and `calc_target_shares` all stay
exact, and the `math.fsum` reduction in `capture_bar` is untouched, so
portfolio equity is bit-identical and order sizing cannot drift.

An earlier experiment that floated share counts diverged — a one-ulp share
difference compounds through `calc_target_shares` into a materially different
backtest — which is why the ledger is left alone here.

`Position.entries` stays the source of truth. The mirror is rebuilt from it
whenever the entry list changes, so nothing is written back on a fill, and the
kernel reports which entries took a new extreme so only those few are
materialized to `Decimal`.

### Measurements

End to end on an idle 4-core box, Python 3.14, 9 paired interleaved reps per
arm, median paired ratio:

| scenario | before | after | ratio | reps |
|---|---|---|---|---|
| pyramided positions | 1.6622s | 1.3477s | **1.232x** | 9/9 |
| single-entry | 1.0030s | 1.0100s | 0.996x | 3/9 |

The kernel amortizes its dispatch cost over a position's entries, so the gain
scales with entries per position and is absent at one entry — hence opt-in,
and hence the asv benchmark is parametrized on the flag rather than averaging
the two paths. With the flag off, against upstream: 1.008x and 1.006x on the
two long scenarios, i.e. no cost when disabled.

**Measurement base:** these numbers were taken against `add22a0`, before this
branch was rebased onto current `dev`. `src/pybroker/portfolio.py` has not been
touched by any commit in that range, so the changed code path is identical —
but the end-to-end baseline now includes the hot-path rework in `a0f6976`, so
the absolute times will have moved. Happy to re-run the paired benchmark
against current `dev` if you want the ratio confirmed on the new base.

### Correctness

The exact `Decimal` path is unchanged and remains the default, so the frozen
oracle tests added in 76c9460 still pass.

Full suite on this rebase, Python 3.12: **5203 passed, 3 failed** — all three
failures are environmental in my sandbox and unrelated to this change:

- `test_ray_backend_dispatches_parallel_indicators` and
  `test_walkforward_parallel_models_ray` — `ActorUnschedulableError: worker
  startup repeatedly failed`, Ray cannot start workers here
- `test_model_input_columns_stable_across_hash_seeds` — spawns a subprocess
  with a replaced `env`, which drops the `PYTHONPATH` my source-tree test run
  depends on

`tests/test_portfolio.py` (229 tests, including the new `fast_marking`
coverage) passes clean.
