### PR TITLE
ci: pin GitHub Actions to commit SHAs, enforce it, and cool down bumps

### DIFF
--- a/.github/actions/setup-pybroker/action.yml
+++ b/.github/actions/setup-pybroker/action.yml
@@ -28,13 +28,13 @@ runs:
         fi
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ~/.cache/pip
         key: pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('setup.cfg', 'requirements.txt') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,16 @@
 version: 2
+
+# A cooldown holds a release back until it has been public for a set
+# number of days. Pinning to a commit SHA freezes what CI runs, but a bot
+# that bumps to a release the hour it appears re-opens the window pinning
+# closed: compromised packages and actions are typically caught within
+# days of publication, so the delay is what turns a pin into protection
+# rather than bookkeeping.
+#
+# GitHub applies a 3-day default; 7 days is chosen here because nothing
+# this repository depends on releases often enough for the wait to cost
+# anything. Security updates ignore cooldown entirely, so this never
+# delays a fix for a known vulnerability.
 updates:
   - package-ecosystem: "pip"
     directory: "/"
@@ -6,9 +18,16 @@ updates:
       interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
+  # github-actions supports only default-days -- the semver-*-days keys
+  # are rejected for this ecosystem, since action tags are not required
+  # to be semver.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "dev"
+    cooldown:
+      default-days: 7

--- a/.github/scripts/check_action_pins.py
+++ b/.github/scripts/check_action_pins.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Assert every GitHub Action is pinned to a full-length commit SHA.
+
+A ``uses:`` reference like ``actions/checkout@v7`` is a *mutable*
+pointer: the action's maintainer moves that tag whenever they ship a
+v7.x, so the code CI executes can change with no commit in this
+repository. ``marocchino/sticky-pull-request-comment@v3`` was not even a
+tag but a branch, which moves on every push.
+
+Pinning to a commit SHA freezes what runs. The trailing ``# v7`` comment
+is only a human-readable label, though -- nothing stops it from drifting
+away from the SHA it claims to describe, and a comment that lies is
+worse than no comment. This check turns both failure modes into a CI
+failure:
+
+* a reference that is not a 40-character commit SHA, and
+* a pinned SHA whose version comment is missing.
+
+Run locally from the repository root:
+
+    python .github/scripts/check_action_pins.py
+
+Pass ``--verify-remote`` to additionally ask the GitHub API whether each
+pinned SHA really belongs to the version its comment names. That needs
+network access, so CI runs it only where a token is available; the
+structural check above is offline and always runs.
+
+Exits 0 when every reference is pinned, 1 with one line per problem
+otherwise.
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+API = "https://api.github.com"
+
+# ``- uses: owner/repo@ref  # comment``. The comment is optional here so
+# that a pinned reference missing its label is reported as a distinct
+# problem rather than skipped as unparseable.
+USES = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)"
+    r"(?:\s+#\s*(?P<comment>.+?))?\s*$"
+)
+SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def workflow_files() -> list[Path]:
+    """Every file that can carry a ``uses:`` reference."""
+    paths = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    paths += sorted((ROOT / ".github" / "workflows").glob("*.yaml"))
+    paths += sorted((ROOT / ".github" / "actions").glob("*/action.yml"))
+    return paths
+
+
+def request(url: str) -> object:
+    """GETs ``url`` as JSON, or returns None when GitHub says no."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "pybroker-check-action-pins",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError:
+        return None
+    except urllib.error.URLError:
+        return None
+
+
+def resolve(repo: str, version: str) -> str:
+    """Resolves a tag or branch name to the commit SHA it points at."""
+    ref = request(f"{API}/repos/{repo}/git/ref/tags/{version}")
+    if ref is None:
+        ref = request(f"{API}/repos/{repo}/git/ref/heads/{version}")
+    if ref is None:
+        return ""
+    obj = ref["object"]  # type: ignore[index]
+    # An annotated tag points at a tag object, which points at the
+    # commit; a lightweight tag points straight at the commit.
+    if obj["type"] == "tag":
+        tag = request(f"{API}/repos/{repo}/git/tags/{obj['sha']}")
+        if tag is None:
+            return ""
+        return str(tag["object"]["sha"])  # type: ignore[index]
+    return str(obj["sha"])
+
+
+def collect(fail: list[str]) -> list[tuple[str, str, str]]:
+    """Checks that every reference is pinned and labelled.
+
+    Returns the ``(repo, sha, version)`` triples worth verifying
+    remotely, so the offline pass decides what the online pass looks at.
+    """
+    pinned: list[tuple[str, str, str]] = []
+    for path in workflow_files():
+        name = path.relative_to(ROOT)
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            match = USES.match(line)
+            if match is None:
+                continue
+            ref = match.group("ref")
+            # A local composite action is this repository's own code; it
+            # moves with the commit under test and cannot be pinned.
+            if ref.startswith("./"):
+                continue
+            if "@" not in ref:
+                fail.append(f"{name}:{number}: {ref!r} has no version at all.")
+                continue
+            repo, _, rev = ref.partition("@")
+            comment = match.group("comment")
+            if not SHA.match(rev):
+                fail.append(
+                    f"{name}:{number}: {repo} is pinned to {rev!r}, which "
+                    "is a mutable tag or branch, not a 40-character "
+                    "commit SHA. The maintainer can move it, changing "
+                    "what CI runs with no commit here."
+                )
+            elif comment is None:
+                fail.append(
+                    f"{name}:{number}: {repo} is pinned to {rev[:7]} with "
+                    "no trailing '# <version>' comment, leaving no way to "
+                    "tell which release it is."
+                )
+            else:
+                pinned.append((repo, rev, comment.split()[0]))
+    return pinned
+
+
+def verify(pinned: list[tuple[str, str, str]]) -> None:
+    """Asks GitHub whether each SHA belongs to the version it claims."""
+    for repo, sha, version in sorted(set(pinned)):
+        actual = resolve(repo, version)
+        if not actual:
+            print(
+                f"  ? {repo}@{sha[:7]} ({version}): could not resolve "
+                "the version -- skipped, not treated as a failure."
+            )
+        elif actual == sha:
+            print(f"  OK {repo}@{sha[:7]} is exactly {version}.")
+        else:
+            # The tag may simply have moved on since this pin was taken,
+            # which Dependabot resolves on its own schedule. Only report
+            # it; a stale pin is safe by construction, and failing here
+            # would turn every upstream release into a red build.
+            print(
+                f"  ~ {repo}@{sha[:7]} is not the current {version} "
+                f"({actual[:7]}). Safe, but outdated -- Dependabot "
+                "should open a bump."
+            )
+
+
+def main() -> int:
+    fail: list[str] = []
+    pinned = collect(fail)
+
+    if fail:
+        print("GitHub Actions are not pinned:\n", file=sys.stderr)
+        for message in fail:
+            print(f"  - {message}", file=sys.stderr)
+        print(
+            "\nPin each reference to the commit SHA its tag resolves to "
+            "and keep the version in a trailing comment, for example:\n"
+            "  uses: actions/checkout@3d3c42e5... # v7",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"All {len(pinned)} action references are pinned to commit SHAs.")
+    if "--verify-remote" in sys.argv:
+        print("Verifying each pin against the GitHub API:")
+        verify(pinned)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       versions: ${{ steps.read.outputs.versions }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Read .github/python-versions.json
         id: read
@@ -43,7 +43,7 @@ jobs:
       matrix:
         python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Upload asv results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: asv-results-py${{ matrix.python }}-${{ github.run_id }}
           path: .asv/results/

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -56,7 +56,7 @@ jobs:
     outputs:
       versions: ${{ steps.read.outputs.versions }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Read .github/python-versions.json
         id: read
@@ -84,7 +84,7 @@ jobs:
       matrix:
         python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -237,7 +237,7 @@ jobs:
         # and this step would fail with "Resource not accessible by integration".
         # Benchmarks still run and results are in the job summary either way.
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: asv-continuous-py${{ matrix.python }}
           path: sticky-comment.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       versions: ${{ steps.read.outputs.versions }}
       tooling: ${{ steps.read.outputs.tooling }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Read .github/python-versions.json
         id: read
@@ -39,9 +39,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -53,9 +53,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -70,9 +70,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -87,9 +87,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -104,9 +104,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -128,9 +128,9 @@ jobs:
       matrix:
         python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
@@ -151,9 +151,9 @@ jobs:
       needs: versions
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v7
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-        - uses: actions/setup-python@v7
+        - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
           with:
             python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -163,7 +163,7 @@ jobs:
         - name: Run build
           run: python -m build --sdist
 
-        - uses: actions/upload-artifact@v7
+        - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
           with:
             path: ./dist/*.tar.gz
 
@@ -181,12 +181,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: artifact
           path: ./dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.14.2
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Check declaration sites against the matrix
         run: python .github/scripts/check_python_versions.py
 
+      - name: Check actions are pinned to commit SHAs
+        run: python .github/scripts/check_action_pins.py
+
   format:
     name: Check formatting
     needs: versions

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Check declaration sites against the matrix
         run: python .github/scripts/check_python_versions.py
 
+      - name: Check actions are pinned to commit SHAs
+        run: |
+          python .github/scripts/check_action_pins.py \
+            --verify-remote
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
   format:
     name: Check formatting
     needs: versions

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -16,7 +16,7 @@ jobs:
       versions: ${{ steps.read.outputs.versions }}
       tooling: ${{ steps.read.outputs.tooling }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Read .github/python-versions.json
         id: read
@@ -40,9 +40,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -54,9 +54,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -71,9 +71,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -88,9 +88,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -105,9 +105,9 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -129,9 +129,9 @@ jobs:
       matrix:
         python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
@@ -152,9 +152,9 @@ jobs:
       needs: versions
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v7
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-        - uses: actions/setup-python@v7
+        - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
           with:
             python-version: ${{ needs.versions.outputs.tooling }}
 
@@ -164,6 +164,6 @@ jobs:
         - name: Run build
           run: python -m build --sdist
 
-        - uses: actions/upload-artifact@v7
+        - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
           with:
             path: ./dist/*.tar.gz


### PR DESCRIPTION
A `uses:` reference like `actions/checkout@v7` is a mutable pointer: the maintainer moves that tag on every v7.x, so the code CI executes can change with no commit here. `marocchino/sticky-pull-request-comment@v3` was not a tag at all but a **branch**, which moves on every push to it.

This pins all 42 external references to the commit their tag resolves to today, keeps them pinned, and stops a bot from undoing the benefit an hour after a release.

## Why this cannot change CI behaviour

Each reference is pinned to the exact commit its tag *already* pointed at, so the runner fetches an identical tree and executes byte-identical action code. The version stays visible in a trailing comment (`# v7`).

Verified on a fork before proposing:

- `Package` — lint, format, typecheck, docs, sdist, tests on 3.11-3.14: green
- `ASV Benchmarks (PR)` — all four legs green, exercising the `setup-pybroker` composite action and the sticky-comment step
- all 7 distinct actions confirmed via the GitHub API to resolve to exactly the version their comment names

No source, benchmark, or packaging file is touched.

## The three commits, separable

1. **`ci: pin GitHub Actions...`** — the 42 `uses:` lines. Self-contained; can land alone.
2. **`ci: fail the build when an action is not pinned`** — `check_action_pins.py`, mirroring `check_python_versions.py`. **See the note below — I would understand dropping this one.**
3. **`ci: hold new releases for 7 days...`** — Dependabot `cooldown`.

## Cooldown: why pinning alone is not enough

A pin freezes what runs, but Dependabot bumping to a release the hour it appears re-opens the window the pin closed. Compromised packages and actions are typically caught within days of publication, so the delay is what turns a pin into protection rather than bookkeeping.

GitHub already applies a 3-day default; this sets 7, because nothing here releases often enough for the wait to cost anything. **Security updates ignore cooldown**, so no vulnerability fix is delayed. `github-actions` accepts only `default-days` (the `semver-*-days` keys are rejected there).

---

## Repository settings you may want to change (optional, not required)

**Nothing here requires a settings change.** The pins and the cooldown are config-file only, and Dependabot is already enabled. The following is optional hardening:

**Enforce pinning at the platform level** — `Settings → Actions → General → Action permissions → Require actions to be pinned to a full-length commit SHA` ([announced Aug 2025](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)). With it on, an unpinned action cannot run at all, so pinning cannot silently regress.

Two cautions if you enable it:

- **Merge this PR first.** The policy applies to *every* workflow in the repo, and any unpinned reference then fails at runtime.
- **It fails late and quietly.** The job dies in ~10s during "Prepare all required actions" with the reason buried in the log — not at review time. That is precisely how this was found: on a fork with the policy enabled, the nightly benchmark workflow had been dying daily because one composite action was still tag-referenced. A linter in CI catches the same problem at PR time, which is why commit 2 (or zizmor) is worth having alongside the policy rather than instead of it.

---

### When the cooldown actually starts applying

Dependabot reads `.github/dependabot.yml` from the **default branch** only ([docs](https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file)). This PR targets `dev`, so the cooldown takes effect once `dev` reaches `master`, not on merge here. `target-branch: dev` is unaffected — that key controls where the PRs are opened, not where the config is read from. The pins and the pin check are branch-local and apply immediately.
## Measured against zizmor, if you want an outside opinion

[`zizmor`](https://docs.zizmor.sh) is the static analyser most of the Python ecosystem has standardised on for workflow security. Run over `dev` today it reports **85 findings** (plus 4 suppressed). This PR clears **44** of them:

| Audit | Severity | On `dev` today | After this PR | Cleared by |
|---|---|---|---|---|
| `unpinned-uses` | High | **42** | 0 | commit 1 |
| `dependabot-cooldown` | Medium | **2** | 0 | commit 3 |
| `excessive-permissions` | High | 1 | 1 | — |
| `excessive-permissions` | Medium | 19 | 19 | — |
| `artipacked` | Low / Medium | 20 | 20 | — |
| `use-trusted-publishing` | Info | 1 | 1 | — |
| **Total reported** | | **85** | **41** | |

`dependabot-cooldown` is a dedicated zizmor audit, so commit 3 is not an idea of mine — it is a rule the tool ships.

`artipacked` is scored Low on `dev` and Medium here. Same 20 occurrences: while the refs are unpinned, `unpinned-uses` dominates those steps; once pinned, credential persistence becomes the remaining concern on them.

<details>
<summary><b>The 41 findings this PR does not address, and how they would be fixed</b></summary>

Listed because they are worth knowing about, **not** as a suggestion to widen this PR. Each is pre-existing and independent of pinning.

**1. `excessive-permissions` — High — `asv-pr.yml:13`**

```
13 |   pull-requests: write
   |   ^^^^ pull-requests: write is overly broad at the workflow level
```

Every job in the workflow receives PR-write, though only the sticky-comment step needs it. Fix: keep `contents: read` at workflow level and grant the narrow scope on the one job:

```yaml
permissions:
  contents: read

jobs:
  continuous:
    permissions:
      contents: read
      pull-requests: write
```

**2. `excessive-permissions` — Medium × 19 — `main.yml`, `schedule.yml`**

Neither workflow declares a `permissions:` block, so every job inherits the repository default. Fix is one line at the top of each:

```yaml
permissions:
  contents: read
```

Worth pairing with a settings check: `Settings → Actions → General → Workflow permissions`. If that is set to *"Read and write permissions"*, every job in both workflows currently gets a read-write `GITHUB_TOKEN`, including the test jobs. Setting it to read-only does not break workflows that declare what they need — explicit `permissions:` blocks still elevate. (I could not read this setting for this repository, only for my fork, where it is `write`.)

**3. `artipacked` — × 20 — every `actions/checkout`**

`actions/checkout` leaves the token in `.git/config` unless told not to. Alone it is minor; it matters in combination with #2 and the fact that `main.yml` uploads artifacts. Fix:

```yaml
- uses: actions/checkout@3d3c42e5... # v7
  with:
    persist-credentials: false
```

zizmor can apply this one automatically (`zizmor --fix`). Only jobs that push back to the repository need the credential.

**4. `use-trusted-publishing` — Informational — `main.yml:195`**

```
password: ${{ secrets.PYPI_API_TOKEN }}
          uses a manually-configured credential instead of Trusted Publishing
```

PyPI Trusted Publishing exchanges a short-lived OIDC token for the upload, removing the long-lived secret entirely. It needs `permissions: id-token: write` on that job plus a publisher configured on the PyPI side, so it is genuinely your call rather than a mechanical change.

</details>

### On commit 2 vs adopting zizmor

`check_action_pins.py` is deliberately minimal: it keeps the pins honest at PR time, which the platform policy cannot do (that fails at runtime, after review). If you would rather adopt zizmor instead, it covers everything commit 2 does — `unpinned-uses` plus `ref-version-mismatch` for a version comment that has drifted from its SHA — and the table above is what you would get on day one. Happy to send that as a follow-up and delete commit 2 in the same change; I have kept them separate so the choice is yours rather than bundled into a pinning PR.
