### PR TITLE
chore: ignore the setuptools build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 docs/build
 docs/_build/
 docs/source/notebooks/.ipynb_checkpoints
+build/
 dist/
 src/lib_pybroker.egg-info
 .idea/


### PR DESCRIPTION
One line. `dist/` and `src/lib_pybroker.egg-info` are already ignored; `build/` is the one sibling setuptools artifact that is not, so it shows up as untracked in any checkout that has been `pip install -e .`-ed or built (31 MB in mine).

Placed next to `dist/` rather than appended, so the three build artifacts stay together.