### PR TITLE
ci: declare least-privilege token scopes and stop persisting credentials

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -22,6 +22,8 @@ jobs:
       versions: ${{ steps.read.outputs.versions }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Read .github/python-versions.json
         id: read
@@ -46,6 +48,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-pybroker
         with:

--- a/.github/workflows/asv-pr.yml
+++ b/.github/workflows/asv-pr.yml
@@ -10,7 +10,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 # Gate thresholds, declared once so the flags and the prose describing
 # them cannot drift apart.
@@ -57,6 +56,8 @@ jobs:
       versions: ${{ steps.read.outputs.versions }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Read .github/python-versions.json
         id: read
@@ -79,6 +80,10 @@ jobs:
     name: asv continuous (Python ${{ matrix.python }})
     needs: versions
     runs-on: ubuntu-latest
+    # Only this job comments on the PR; `versions` does not need it.
+    permissions:
+      contents: read
+      pull-requests: write  # `Post sticky PR comment` needs this.
     strategy:
       fail-fast: false
       matrix:
@@ -87,6 +92,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-pybroker
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ name: Package
 on:
   - push
 
+# The default GITHUB_TOKEN scope depends on a repository setting, so
+# declare it here: every job in this workflow only reads the checkout.
+permissions:
+  contents: read
+
 jobs:
   # Single source of truth for every Python version this workflow uses.
   # `versions` drives the test matrix; `tooling` pins the one interpreter
@@ -16,6 +21,8 @@ jobs:
       tooling: ${{ steps.read.outputs.tooling }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Read .github/python-versions.json
         id: read
@@ -40,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -57,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -74,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -91,6 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -108,6 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -132,6 +149,8 @@ jobs:
         python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -155,6 +174,8 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+          with:
+            persist-credentials: false
 
         - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
           with:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 12 * * *'
 
+# The default GITHUB_TOKEN scope depends on a repository setting, so
+# declare it here: every job in this workflow only reads the checkout.
+permissions:
+  contents: read
+
 jobs:
   # Single source of truth for every Python version this workflow uses.
   # `versions` drives the test matrix; `tooling` pins the one interpreter
@@ -17,6 +22,8 @@ jobs:
       tooling: ${{ steps.read.outputs.tooling }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Read .github/python-versions.json
         id: read
@@ -41,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -62,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -79,6 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -96,6 +109,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -113,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -137,6 +154,8 @@ jobs:
         python: ${{ fromJSON(needs.versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -160,6 +179,8 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+          with:
+            persist-credentials: false
 
         - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
           with:


### PR DESCRIPTION
Two related hardening changes, both surfaced by [`zizmor`](https://docs.zizmor.sh) run against `dev`. No behaviour change to what any job does.

## Token scopes

`main.yml` and `schedule.yml` declare no `permissions:` block, so every job inherits the repository default. That default is a *repository setting*, not anything visible in the file — so the scope these jobs run with cannot be determined by reading the workflow. Where the setting is "Read and write permissions", the entire test matrix runs with a read-write `GITHUB_TOKEN` it never uses. Both now declare `contents: read`.

`asv-pr.yml` granted `pull-requests: write` at workflow level, which also handed it to `versions`. Only `benchmark` posts the sticky comment, so the scope moves down to that job.

## Credential persistence

`actions/checkout` leaves the token in `.git/config` unless `persist-credentials: false`. Nothing in these workflows pushes back to the repository, so all 20 checkouts opt out. It matters most in combination with the above — `main.yml` uploads artifacts, and a persisted credential is one way a token ends up inside one.

## Effect

Measured with `zizmor --offline`:

| | `dev` today | with this PR |
|---|---|---|
| `artipacked` | 20 | **0** |
| `excessive-permissions` (Medium) | 19 | **0** |
| `excessive-permissions` (High) | 1 | **0** |
| **Total reported** | 85 | **45** |

The remaining 45 are `unpinned-uses` (42) and `dependabot-cooldown` (2), both addressed by #309, plus one informational `use-trusted-publishing` — that one needs a publisher configured on PyPI, so it is deliberately left alone.

The `persist-credentials` edits were applied with `zizmor --fix`; the `permissions:` blocks are hand-written, since it does not auto-fix those.

Independent of #309 — the two touch different lines and can land in either order.