### PR TITLE
ci: stop the benchmark gate blocking on disk-I/O noise

### DIFF
--- a/.github/scripts/asv_gate.py
+++ b/.github/scripts/asv_gate.py
@@ -21,7 +21,10 @@ short the benchmark is, not of the threshold: no factor separates signal
 from noise down there, it only trades false positives for blindness.
 
 This gates on both axes. A benchmark blocks only when it is slow enough
-to measure on a noisy runner *and* it regressed past the factor.
+to measure on a noisy runner *and* it regressed past the factor. One
+exception overrides even that: benchmarks timing disk I/O rather than
+pybroker code never block, because for them duration is not a proxy for
+quiet -- see ``IO_BOUND``.
 Everything else is reported, so a real microbenchmark regression stays
 visible to a human -- it just does not block a PR on a coin flip.
 
@@ -33,10 +36,36 @@ seconds, so there is no rendered table to parse and no units to convert.
 import argparse
 import itertools
 import sys
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 from asv.config import Config
 from asv.results import iter_results_for_machine_and_hash
+
+# Benchmarks whose timed section is dominated by filesystem I/O rather
+# than by pybroker code. The duration floor assumes a slower benchmark is
+# a quieter one, which holds while the runtime is CPU work and fails for
+# disk: ``DataSourceCacheWrite.time_cache_write`` blocked a PR whose
+# ``src/`` and ``benchmarks/`` were byte-identical to base, at 1.48x
+# (28.7ms -> 42.6ms), and re-running that same job on that same commit
+# passed. At 28ms it clears any floor low enough to still catch a real
+# regression, so duration cannot separate it from noise -- what varies is
+# the runner's disk, not this project. The table above says the same from
+# the other direction: ``CacheDiskHit`` read 1.18 on one leg and 0.65 on
+# another with nothing changed.
+#
+# These are reported, never blocking. ``CacheL1Hit`` is deliberately not
+# here: it reads an in-process dict and is ordinary CPU work.
+IO_BOUND: Final = (
+    "bench_data.DataSourceCacheRead.",
+    "bench_data.DataSourceCacheWrite.",
+    "bench_backtest.CacheHit.",
+    "bench_backtest.CacheDiskHit.",
+)
+
+
+def is_io_bound(name: str) -> bool:
+    """Whether a benchmark measures the runner's disk more than this code."""
+    return name.startswith(IO_BOUND)
 
 
 def format_seconds(seconds: float) -> str:
@@ -110,9 +139,11 @@ def classify(
     """Splits changed benchmarks into blocking, reported and improved.
 
     A benchmark blocks only if it is both slower than ``factor`` and slow
-    enough overall to be measurable (``floor``). Everything that moved by
-    ``report_factor`` either way is still reported, so a microbenchmark
-    regression is visible even though it cannot block.
+    enough overall to be measurable (``floor``), and is not one of the
+    ``IO_BOUND`` benchmarks, for which duration says nothing about noise.
+    Everything that moved by ``report_factor`` either way is still
+    reported, so a microbenchmark regression is visible even though it
+    cannot block.
     """
     blocking: list[Change] = []
     reported: list[Change] = []
@@ -123,7 +154,7 @@ def classify(
         if not old > 0.0:
             continue
         change = Change(name, old, new)
-        if change.ratio >= factor and old >= floor:
+        if change.ratio >= factor and old >= floor and not is_io_bound(name):
             blocking.append(change)
         elif change.ratio >= report_factor:
             reported.append(change)
@@ -189,9 +220,14 @@ def main() -> int:
             "the factor):"
         )
         for change in verdict.reported:
+            why = (
+                " [I/O-bound, never blocks]"
+                if is_io_bound(change.name)
+                else ""
+            )
             print(
                 f"  {change.ratio:>5.2f}  {change.name}  "
-                f"(baseline {format_seconds(change.before)})"
+                f"(baseline {format_seconds(change.before)}){why}"
             )
     if verdict.blocking:
         print(


### PR DESCRIPTION
The duration floor rests on an assumption that holds for CPU work and fails for disk: **that a slower benchmark is a quieter one.**

## What happened

A PR whose `src/` and `benchmarks/` were byte-identical to base was blocked:

```
1.48  bench_data.DataSourceCacheWrite.time_cache_write  (28.7423ms -> 42.6315ms)
```

Python 3.11 leg only; 3.12, 3.13 and 3.14 all passed. Re-running that same job on that same commit passed. **A real 1.48x regression does not fix itself on a re-run.**

## Why the floor cannot fix this

At 28ms it clears any `--min-seconds` still low enough to catch a genuine regression, so there is no threshold that separates it from noise. What varies between runs is the shared runner's disk, not this project.

The noise table already in `asv_gate.py` says the same thing from the other direction: `CacheDiskHit` read **1.18 on one leg and 0.65 on another** with nothing changed. That is a disk benchmark too — it just happened to sit under the floor, so it was never able to block.

## The change

Four benchmarks whose timed section is dominated by filesystem I/O are reported and never block:

- `bench_data.DataSourceCacheRead` / `DataSourceCacheWrite` — 50 symbols through diskcache
- `bench_backtest.CacheHit` — raw diskcache read
- `bench_backtest.CacheDiskHit` — L1 cleared, so it is forced to disk

`CacheL1Hit` is deliberately **not** in the list: it reads an in-process dict, which is ordinary CPU work and should stay gated. That distinction is the whole point — the exemption is "measures the runner's disk", not "has Cache in the name".

The report labels exempted entries `[I/O-bound, never blocks]`, so this is visible rather than a silent hole.

## Verification

Logic exercised directly against the real numbers: the 1.48x case now reports instead of blocking; `CacheL1Hit` at 2.00x still blocks; `Walkforward` at 1.40x still blocks; a 1.50x microbenchmark still reports. `ruff format` and `ruff check` clean.

Independent of #309 and #311.