### PR TITLE
skill: always read the tag-to-tag diff, and trigger triage on any bump

### DIFF
--- a/.claude/skills/dependency-migration-triage/SKILL.md
+++ b/.claude/skills/dependency-migration-triage/SKILL.md
@@ -3,8 +3,11 @@ name: dependency-migration-triage
 description: >
   Rigorously triage a single Dependabot (or Renovate) dependency version-bump PR: pull the
   real changelog/release notes across the full old->new version range (not the PyPI summary
-  blurb), map it against actual usage sites in this codebase, write a migration plan that
-  distinguishes API-signature changes from conceptual/behavioral ones (a version bump can
+  blurb), always read the actual source diff between the two tags as well - a changelog
+  records what changed and can never record what stayed the same, which is what most
+  "we are unaffected" arguments actually rest on - map both against
+  actual usage sites in this codebase, write a migration plan that distinguishes
+  API-signature changes from conceptual/behavioral ones (a version bump can
   quietly change defaults or strictness with no signature change at all), verify whether
   existing tests would actually catch a regression in that exact spot or merely execute the
   line with stale data, write a regression test that fails on the old behavior when a real
@@ -30,7 +33,7 @@ need to adapt because of it." A green CI run on the bump PR itself is necessary 
 sufficient: CI only proves the currently-selected checks still pass, and says nothing about
 whether those checks were ever capable of catching the specific thing that changed. Two real
 findings from this repo's own history illustrate why that distinction matters — read
-`references/case-studies.md` before Phase 3 if this is your first time running this skill,
+`references/case-studies.md` before Phase 4 if this is your first time running this skill,
 or whenever a phase result feels uncertain.
 
 Work through these phases in order. Scale depth to actual signal (see the "Right-size the
@@ -52,7 +55,7 @@ and diff.
 - How big is the jump — a patch release, or several majors/many minors? Bigger jumps need
   more changelog reading, not more assumption.
 - Does this repo's test suite even exercise the dependency's usage sites at all (see Phase
-  4)? If a dependency has zero test coverage today, that's itself a finding worth surfacing
+  5)? If a dependency has zero test coverage today, that's itself a finding worth surfacing
   regardless of whether this particular bump breaks anything.
 A one-line patch bump of an unused-by-default dev tool can reasonably get a light pass. A
 major-version bump of something `src/` imports directly cannot.
@@ -68,20 +71,94 @@ version's notes — confirm this is true for the specific project rather than as
 WebFetch/WebSearch. For a wide range, you don't need to quote every entry — you need to have
 actually read enough to know whether something in it touches what this repo uses.
 
-## Phase 2 — Map to actual usage
+## Phase 2 — Read the diff between the two tags
+
+Do this on every bump, including ones with a good changelog. A changelog records what
+changed; it can never record what *stayed the same* — and most reachability arguments are
+claims about the absence of change ("we're fine because the class we subclass is
+untouched"). No prose will ever state that for you. The diff is also the only thing that
+pins a change to an exact version and an exact symbol.
+
+So the diff does two different jobs depending on what else exists:
+
+- **No usable changelog** — an absent or empty GitHub release, notes that live only in an
+  in-repo `CHANGES.rst`/`HISTORY.rst`, a bare dump of PR titles. Then the diff is the only
+  primary source there is, and "I read the changelog" is a claim you are not in a position
+  to make.
+- **A usable changelog** — then it gives you leads and the diff turns them into proof, far
+  more cheaply, because the prose already told you which files to open. An entry saying
+  "add lazy random state in samplers" becomes "`sampler._rng` changed from
+  `numpy.random.RandomState` to a `LazyRandomState` wrapper, at exactly v3.4.0" — which is
+  the difference between suspecting a problem and being able to act on one.
+
+Compare the tags directly — no clone needed:
+
+```
+gh api repos/<owner>/<repo>/compare/<old-tag>...<new-tag> \
+  --jq '.commits[] | "- " + (.commit.message | split("\n")[0])'
+gh api repos/<owner>/<repo>/compare/<old-tag>...<new-tag> \
+  --jq '.files[] | "\(.status) \(.filename) +\(.additions)/-\(.deletions)"'
+```
+
+Add `| select(.filename == "<path>") | .patch` to read one file's hunks.
+
+**`compare` truncates silently on wide ranges, and the failure mode is a false negative.**
+Over many versions GitHub drops the `patch` field and then drops files from `.files`
+altogether — with no error and no marker. Measured on joblib: `1.2.0...1.5.3` returns 134
+files, 37 with `patch == null`, and omits `joblib/parallel.py` **entirely** despite it
+changing by 542 lines; narrowing to `1.4.2...1.5.3` returns it with its patch intact. Read
+naively, "the file isn't in the list" becomes "the file didn't change" — the exact opposite
+of the truth, on the file that mattered most.
+
+Two habits make that safe:
+- **Step through the range** one minor at a time rather than spanning it in one call, and
+  treat a single wide compare as a survey, never as evidence of absence.
+- **Never conclude "unchanged" from a file's absence.** If a file you expected to change
+  isn't listed, narrow the range until it appears, or fetch it at both tags and diff
+  locally (`gh api repos/<o>/<r>/contents/<path>?ref=<tag> --jq .content | base64 -d`).
+  Absence of evidence here really is not evidence of absence.
+
+Extract, in the order that decides things:
+
+1. **Which files changed.** Cross-reference against Phase 3's usage sites. A change confined
+   to a subpackage this codebase never imports is unreachable, full stop.
+2. **The patch for the files that *are* reachable** — and, for anything you intend to call
+   safe, confirmation that its source is genuinely untouched rather than merely unmentioned.
+3. **Packaging metadata** — `requires-python`, dependency pins, version ceilings. These
+   decide what can resolve at all and are routinely absent from the prose.
+
+Worked outcomes, all from real runs of this skill:
+
+- **Sole source.** mypy 2.3.0 → 2.3.1 had no GitHub release. The diff was six commits; the
+  only non-mypyc change replaced an `assert isinstance(...)` with a conditional to fix a
+  crash — a *proof* the bump cannot newly reject previously-accepted code, which no
+  changelog existed to state.
+- **Scoping a vague warning.** alpaca-py 0.44.0's notes flagged one item "Breaking Change"
+  with no scope. The file list showed it touching `alpaca/trading/requests.py` only, against
+  a codebase that imports `alpaca.data` exclusively. Unreachable, settled in one command.
+- **Proving non-change.** For a pytest-randomly 3.12 → 4.1 major bump, the questions that
+  mattered were whether `-p no:randomly` still worked and whether xdist seed propagation
+  survived. The diff answered both by showing the `pytest11` entry-point name and the
+  `XdistHooks` class body byte-identical across the tags. A changelog cannot tell you that
+  something is unchanged; only the diff can.
+
+Track which source each later claim rests on. "Read in the diff" and "stated in the
+changelog" are different strengths of evidence, and Phase 8 asks you to report them apart.
+
+## Phase 3 — Map to actual usage
 
 Grep `src/`, `tests/`, and (if that's the *only* place the dependency shows up) `docs/`
 notebooks for every real call site — imports, function/class usage, config file settings
 that reference the tool. Don't reason from the dependency's own docs in the abstract; ground
 every claim in this codebase's actual call sites, with file:line references. If a dependency
 isn't used anywhere in `src/` or `tests/`, say so plainly — that changes everything
-downstream (see Phase 4).
+downstream (see Phase 5).
 
-## Phase 3 — Migration plan: API changes AND conceptual/behavioral ones
+## Phase 4 — Migration plan: API changes AND conceptual/behavioral ones
 
-For each usage site found in Phase 2, cross-reference against Phase 1's changelog and
-classify: **safe as-is** / **trivial fix** (renamed param, deprecated arg, config key rename)
-/ **real code change needed** / **new concept to adopt**.
+For each usage site found in Phase 3, cross-reference against Phase 1's changelog and
+Phase 2's diff, and classify: **safe as-is** / **trivial fix** (renamed param, deprecated
+arg, config key rename) / **real code change needed** / **new concept to adopt**.
 
 The trap to avoid: only checking whether a function signature changed. Some of the most
 consequential changes in a version bump are changes to *default behavior* with no signature
@@ -92,9 +169,9 @@ repo's own history. Ask explicitly, for each usage site: "if I changed nothing i
 could this dependency's new version make this line do something different than before?" —
 that question catches what a signature diff alone won't.
 
-## Phase 4 — Coverage check: does a test actually cover *this*, or just execute the line?
+## Phase 5 — Coverage check: does a test actually cover *this*, or just execute the line?
 
-For every usage site flagged as anything other than "safe as-is" in Phase 3, find the
+For every usage site flagged as anything other than "safe as-is" in Phase 4, find the
 test(s) that exercise it and read them — don't just check whether coverage tooling marks the
 line as executed. Ask: does the test construct the *specific input/shape* that the changed
 behavior would affect, with *live* logic (or a mock/fixture reflecting the *new* reality), or
@@ -118,32 +195,32 @@ verified the new version of a dependency built cleanly, concluded "safe, nothing
 never noticed the old version actually crashed against the current environment — something a
 same-effort comparison against the old version would have caught immediately.
 
-## Phase 5 — Write a regression test, only when there's a real finding
+## Phase 6 — Write a regression test, only when there's a real finding
 
-If Phase 3/4 turned up an actual breaking change with inadequate coverage: write a test that
+If Phase 4/5 turned up an actual breaking change with inadequate coverage: write a test that
 constructs the exact input/shape that exposes it, and **prove it's a real regression test, not
-a plausible-sounding one** — reproduce the old buggy behavior directly (revert your Phase 6
+a plausible-sounding one** — reproduce the old buggy behavior directly (revert your Phase 7
 fix locally, or hand-run the old logic in a scratch snippet) and confirm the new test fails
 against it, then reinstate the fix and confirm it passes. This is the difference between "I
 think this would have failed" and "I watched it fail."
 
-If Phase 3/4 found nothing wrong: say so and stop here. Don't manufacture a test to look
+If Phase 4/5 found nothing wrong: say so and stop here. Don't manufacture a test to look
 thorough — a fabricated regression test for a non-issue is noise that looks like rigor, and
 future readers can't tell the difference between "this guards something real" and "this pads
 the diff" unless you're honest about which is which right now.
 
-## Phase 6 — Fix what's fixable
+## Phase 7 — Fix what's fixable
 
 Mechanical/trivial migrations (deprecation warnings, renamed parameters, config key renames,
 newly-required explicit arguments) get fixed inline as part of this same pass — don't leave
 free wins for a human to redo. Real breaking changes get a proper code fix paired with the
-Phase 5 regression test. If something needs a genuinely new concept adopted (not just a
+Phase 6 regression test. If something needs a genuinely new concept adopted (not just a
 find-replace), implement it, but flag in the PR description that this is a judgment call the
 maintainer may want to review more closely than a mechanical fix.
 
 **If this phase produced a real code change** (skip this entirely for a comment-only, nothing-
 to-fix outcome — running either of these against a no-op finding is pure overhead), close the
-loop on your own work before moving to Phase 7:
+loop on your own work before moving to Phase 8:
 
 - Run the `silent-failure-hunter` agent (from the `pr-review-toolkit` plugin, if available in
   this environment — otherwise apply the same lens yourself: does the fix swallow an error
@@ -157,16 +234,19 @@ loop on your own work before moving to Phase 7:
   proceeding. Skip this for everything else — most triages never go near credentials, and
   running it by default would be blanket overhead for no signal.
 
-## Phase 7 — Open a PR that mirrors the migration
+## Phase 8 — Open a PR that mirrors the migration
 
 Open a PR (same repo/branch conventions as the rest of this project — check recent merged
-PRs for the base branch, typically `dev`) containing the Phase 6 fix and Phase 5 test. The
+PRs for the base branch, typically `dev`) containing the Phase 7 fix and Phase 6 test. The
 PR description must:
 - Link/reference the originating Dependabot PR number explicitly, so the maintainer can find
   it from either direction.
-- State plainly what was *verified by executing something* (a test that really failed then
-  passed, a notebook actually run, `mypy`/`ruff` actually invoked with the new version)
-  versus what was *inferred from changelogs* — don't blur the two. If nothing needed fixing,
+- State plainly which of three tiers each claim rests on, and don't blur them: *verified by
+  executing something* (a test that really failed then passed, a notebook actually run,
+  `mypy`/`ruff` actually invoked with the new version), *read in the diff* (Phase 2 — a file
+  list proving unreachability, a hunk read directly), or *inferred from changelogs*. The
+  middle tier is the one that gets silently promoted to the first or demoted to the third;
+  name it as its own thing. If nothing needed fixing,
   the PR (or a comment on the Dependabot PR, if a whole new PR would be empty) should say
   plainly "verified — the following was checked and nothing needs to change," not stay
   silent.

--- a/.claude/skills/dependency-migration-triage/references/case-studies.md
+++ b/.claude/skills/dependency-migration-triage/references/case-studies.md
@@ -1,7 +1,7 @@
 # Case studies: what this skill exists to catch (and not overclaim)
 
 Three real findings from this repo, each illustrating a different failure mode the phases in
-SKILL.md are designed to catch. Read before Phase 3/4 if a result feels uncertain, or as a
+SKILL.md are designed to catch. Read before Phase 4/5 if a result feels uncertain, or as a
 sanity check on your own findings before writing them up.
 
 ## 1. Conceptual/behavioral change with no signature change (mypy)
@@ -21,7 +21,7 @@ looks like without touching any function signature this repo calls.
 The lesson: when triaging a type-checker, linter, or any tool whose whole job is "decide
 whether code is correct," don't just check for removed functions or renamed parameters —
 ask whether the tool's *definition of correct* changed. Running the new version against the
-real codebase (Phase 3) is the only way to find this; changelog-reading alone under-reports
+real codebase (Phase 4) is the only way to find this; changelog-reading alone under-reports
 it unless the changelog explicitly calls out "stricter narrowing" or similar, and even then
 you won't know which lines it touches without running it.
 
@@ -48,7 +48,7 @@ akshare bump — because it mocked the fallback API's return value using the **o
 The line executed every time; the mock never reflected the new reality, so the test could
 never have caught this regression no matter how many times it ran.
 
-The lesson (Phase 4): "this line has test coverage" and "a test here would catch a real
+The lesson (Phase 5): "this line has test coverage" and "a test here would catch a real
 regression" are different claims. The only way to tell them apart is to read what shape of
 data the test actually constructs and ask whether that shape still matches what the
 dependency's new version actually returns — not whether the assertion count is nonzero.
@@ -80,7 +80,7 @@ not defaulting to belief or disbelief.
 
 During this skill's own calibration, one run triaged an `nbsphinx` bump that had zero test or
 CI coverage (docs-tooling-only, nothing in the pipeline builds the docs). Correctly following
-Phase 4's instinct to become the coverage, it built the actual documentation with the *new*
+Phase 5's instinct to become the coverage, it built the actual documentation with the *new*
 nbsphinx version, watched it succeed with zero warnings, and concluded "safe, nothing to
 fix" — a clean, confident verdict, arrived at by actually executing something rather than
 just reading a changelog.
@@ -93,7 +93,7 @@ only thing keeping the documentation buildable at all. The skill-following run n
 discovered this because it only ever asked "does the new version work," never "was the old
 version already broken."
 
-The lesson (why Phase 4 now says to check both directions): confirming the new version works
+The lesson (why Phase 5 now says to check both directions): confirming the new version works
 answers half the question. It catches regressions but is blind to the mirror case — a bump
 that's actually a load-bearing fix — because "safe, nothing to fix" and "safe, and here's
 what it silently fixed" look identical from the forward-only check alone. Whenever you're

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,43 @@ users symlink them into their agent's skills directory
       `symbols=` controls — not a blanket replacement for the metrics
       print, since the default JSON payload is usually larger.
 
+## Dependency Bumps
+
+**Any diff that moves a version constraint — `requirements.txt`,
+`setup.cfg`, `pyproject.toml`, or a `uses:` ref in
+`.github/workflows/` — is triaged with the
+`dependency-migration-triage` skill before it is judged.** That includes
+Dependabot PRs, a bump you are asked to review, and one you make
+yourself. Green CI is necessary and not sufficient: it proves the
+selected checks still pass, never that any of them was capable of
+catching what changed. Do not eyeball a bump and call it safe; the skill
+exists because the expensive findings hide in bumps everyone assumes are
+boring.
+
+Two things about this repo save a triage from rediscovering them:
+
+- **`requirements.txt` governs only the docs builds** — `[testenv:docs]`
+  and `.readthedocs.yml`, both on Python 3.12, plus a `hashFiles` cache
+  key. It does not feed the test matrix. `install_requires` in
+  `setup.cfg` is what users actually resolve, `[testenv:typecheck]` pins
+  mypy exactly, and `[testenv:lint]`/`[testenv:format]` install **ruff
+  unpinned**. So a `requirements.txt` floor bump usually changes nothing
+  CI does — always check whether the matching `setup.cfg` constraint is
+  the one that needed to move.
+- **The floors are open-ended `>=`**, so a fresh install already resolves
+  to the post-bump version. Reproducing a "before" arm needs `==` pins;
+  without them both arms of a comparison install the same thing and the
+  experiment measures nothing.
+
+Numeric and compiled dependencies (`numpy`, `numba`, `llvmlite`,
+`pandas`) carry one extra obligation, because determinism is a shipped
+feature: prove results are **bit-identical**, not merely that tests pass.
+Run a seeded backtest over `tests/testdata/daily_1.pkl` on both arms and
+diff full-precision `EvalMetrics` plus hashes of the portfolio,
+positions, orders, trades and bootstrap frames. Leave the performance
+verdict to the asv gate — see § Performance & Benchmarks on why a number
+measured on a loaded workstation is worthless.
+
 ## Project Rules
 
 - **Never add columns to, widen, or copy the user's input DataFrame.**


### PR DESCRIPTION
Adds a diff-reading phase to the `dependency-migration-triage` skill
(contributed in #251, moved under `.claude/` in `551c5c9`) and a CLAUDE.md rule
that fires the skill on any version-constraint change.

## Why the phase is unconditional

It would be natural to read the source diff only when release notes are missing.
That is the wrong rule. **A changelog records what changed and can never record
what stayed the same** — and most "we are unaffected" conclusions are claims
about the *absence* of change.

Triaging a pytest-randomly `3.12 → 4.1` bump, the two questions that mattered
were whether `-p no:randomly` still works and whether xdist seed propagation
survives. Both were answered only by the diff, showing the `pytest11`
entry-point name and the `XdistHooks` class body **byte-identical** across the
tags. No changelog states that something is unchanged.

Where notes do exist they make the diff *cheaper*, by naming which files to
open. Optuna's one-line "add lazy random state in samplers" became
"`sampler._rng` changed from `RandomState` to a `LazyRandomState` wrapper at
exactly v3.4.0" — the difference between suspecting a problem and being able to
act on one.

## A warning the recipe needed, found by running it

`gh api .../compare/<old>...<new>` truncates silently on wide ranges: it drops
the `patch` field, then drops files from `.files` altogether, with no error and
no marker. Measured on joblib:

| range | files listed | `patch == null` | `joblib/parallel.py` |
|---|---|---|---|
| `1.2.0...1.5.3` | 134 | 37 | **absent** (despite +542 lines) |
| `1.4.2...1.5.3` | 108 | 9 | present, with patch |

Read naively, "not in the list" becomes "did not change" — a false negative on
the file that mattered most. The phase now says to step through the range one
minor at a time and never to conclude "unchanged" from a file's absence,
with a local-fetch fallback for when a patch is withheld.

## What the change is actually worth

Measured against the previous version of the skill across three bumps (joblib,
pytest-randomly, optuna), same model both arms: the new phase changed what the
run did on **one of three** — the case where the GitHub release body was empty
and the old version read `CHANGES.rst` and never looked at code. On the other
two, both versions diffed unprompted.

So it makes an emergent behaviour reliable rather than introducing one. That is
a smaller claim than "the model could not do this before", and it is the one the
evidence supports. Token and wall-clock cost came out a wash (152.6k/1363s vs
156.9k/1260s mean, n=3).

Phase 8 additionally separates three evidence tiers — executed, read in the
diff, inferred from prose — because the middle tier kept being silently promoted
to the first or demoted to the third. The one run that skipped tiering entirely
was an old-version run.

## The CLAUDE.md rule

Fires the skill on any diff moving a constraint in `requirements.txt`,
`setup.cfg`, `pyproject.toml` or a workflow `uses:` ref, and records two
repo-specific facts so a triage does not rediscover them: `requirements.txt`
governs only `[testenv:docs]` and `.readthedocs.yml` (so a floor bump there is
usually inert for CI, and `setup.cfg` is often the file that needed to move),
and the floors are open-ended `>=` (so a fresh install already resolves to the
post-bump version, and reproducing a "before" arm needs `==` pins). Numeric and
compiled dependencies additionally require a bit-identity check rather than a
passing suite, with the performance verdict left to the asv gate.

## Provenance

Every example and number above comes from real runs, not illustration. Three
triages were executed twice each — once under this version, once under the
version currently on `dev` — and the findings are what the phase text now cites.
