### PR TITLE
deps: floor optuna at 3.4, and unwind the re-seed's dead branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.11
 install_requires =
-    optuna>=3.1,<5
+    optuna>=3.4,<5
     alpaca-py>=0.10.0,<1
     diskcache>=5.4.0,<6
     joblib>=1.2.0,<2

--- a/src/pybroker/optimize.py
+++ b/src/pybroker/optimize.py
@@ -539,6 +539,16 @@ def _reseed_sampler(sampler: BaseSampler, seed: int, _depth: int = 0) -> None:
     defensively and leaves a sampler that does not expose it -- a third-party
     subclass, say -- untouched rather than raising.
 
+    ``LazyRandomState.rng`` is a read-only property, so the generator it
+    wraps is replaced rather than assigned through -- hence reaching one
+    level further in, to ``_rng._rng``.
+
+    That wrapper is why ``install_requires`` floors optuna at 3.4: before
+    3.4 the generator sat directly on ``_rng`` with nothing to reach
+    through, the guard below would not match, and the sampler would keep
+    its original stream -- ``seed=`` buying no reproducibility at all,
+    silently. Do not lower that floor without handling the older shape.
+
     Recurses into delegated inner samplers: ``TPESampler`` draws its first
     ``n_startup_trials`` from an inner ``RandomSampler``, so with the small
     per-window trial counts a walkforward uses, re-seeding only the outer
@@ -549,13 +559,8 @@ def _reseed_sampler(sampler: BaseSampler, seed: int, _depth: int = 0) -> None:
     if _depth > 3:
         return
     rng = getattr(sampler, "_rng", None)
-    if rng is not None:
-        state = np.random.RandomState(seed)
-        try:
-            rng.rng = state
-        except AttributeError:
-            if hasattr(rng, "_rng"):
-                rng._rng = state
+    if rng is not None and hasattr(rng, "_rng"):
+        rng._rng = np.random.RandomState(seed)
     for offset, attr in enumerate(
         ("_random_sampler", "_independent_sampler", "_base_sampler")
     ):


### PR DESCRIPTION
`install_requires` declared `optuna>=3.1`, but `_reseed_sampler` depends on a
wrapper optuna only introduced in **3.4.0**. On 3.1–3.3 it silently does
nothing. Narrowing the range then exposed that the surrounding `try/except` had
never worked either. Filed as Pirat83/pybroker#42.

## The bug

`_reseed_sampler` re-seeds by reaching into the sampler's private `_rng`, which
is a `LazyRandomState`. That class arrived in **3.4.0** — established from the
source tree, not release notes: `optuna/samplers/_lazy_random_state.py` is
**absent at `v3.3.0`, present at `v3.4.0`**. Before 3.4 the generator sits
directly on `_rng`, there is no wrapper to reach through, and the re-seed does
nothing at all. No error, no warning — from the one code path whose purpose is
making `seed=` reproducible across walkforward windows when a user supplies
their own sampler.

### Verified against a real optuna 3.1.0 install

All three samplers `_build_sampler` can construct — `TPESampler`,
`RandomSampler`, `GridSampler` — hold `_rng` as a bare
`numpy.random.mtrand.RandomState` on 3.1.0. Two invariants, both versions:

| | optuna 3.1.0 | optuna 4.9.0 |
|---|---|---|
| different re-seeds → draws diverge | ❌ byte-identical | ✅ |
| same re-seed → draws agree | ❌ | ✅ |

Both come out **inverted** on 3.1.0, because only the constructor seed ever took
effect.

## Fix 1 — raise the floor

```
-    optuna>=3.1,<5
+    optuna>=3.4,<5
```

The alternative was branching on the old shape; I prototyped that and confirmed
it works, but raising the floor keeps one supported path in the code rather than
carrying a compatibility branch for versions nobody should resolve. The
docstring now records **why** the floor is 3.4 and what breaks silently below
it, so it is not lowered later by someone reading only the code.
`requirements.txt` already sits at `>=4.9.0` and is unaffected — it governs only
the docs env.

## Fix 2 — the `try/except` was inside out

With 3.1–3.3 out of range it became clear the exception handling protected
nothing:

```python
try:
    rng.rng = state          # never succeeds
except AttributeError:
    if hasattr(rng, "_rng"):
        rng._rng = state     # this is the actual implementation
```

**`LazyRandomState.rng` is a read-only property** — no setter at `v3.4.0`,
`v4.0.0` or `v4.9.0`, checked at each tag. So `rng.rng = state` has never
succeeded anywhere in the supported range, and the real assignment was living in
the handler. Eight lines of exception-driven control flow become a guard that
states what happens:

```python
rng = getattr(sampler, "_rng", None)
if rng is not None and hasattr(rng, "_rng"):
    rng._rng = np.random.RandomState(seed)
```

Unknown shapes are still skipped rather than raising, which the docstring
already described as deliberate for third-party subclasses. The doubled `_rng`
now has an explanation next to it, since it otherwise reads as a typo.

**Behaviour is unchanged in the strong sense**: the same seeded draw comparison
run against the old body and the new one produces byte-identical output. Not
merely "the tests still pass".

## No test

Once the floor excludes the broken range there is nothing left to guard: the
matrix resolves 4.x, and a test simulating the pre-3.4 shape would assert
behaviour this PR deliberately stops supporting. The prototype branch did carry
a regression test, proven by reverting the fix and watching it fail; it was
dropped along with the branch rather than kept as decoration.

## Checks

`ruff format --diff` clean · `ruff check` clean · `mypy --warn-unused-ignores`
clean · `tests/test_optimize.py` 59/59 · **full suite 5224 passed**.
