### PR TITLE
deps: declare typing_extensions, and use what it makes available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,22 @@ between runs on NumPy arrays and Numba kernels.
   use Python 3.12 `type` statements that mypy rejects when
   `python_version` is 3.11, and 3.11 cannot install numpy 2.5.
   `check_python_versions.py` enforces this; it moves when tooling moves.
+- Typing imports: take a name from `typing` when it exists on the supported
+  floor (3.11); reach for `typing_extensions` only for features newer than
+  that floor — today exactly `override` (stdlib 3.12) and `TypeIs` (stdlib
+  3.13). `typing_extensions` re-exports the stdlib object where one exists,
+  so this is not a backport shim. It is a declared runtime dependency
+  (`install_requires`), not a dev-only one.
+- Exhaustive `if/elif` over an `Enum` or `Literal` ends with
+  `_unreachable_<what>: Never = <expr>` before the existing `raise
+  ValueError(...)`. That gets mypy's exhaustiveness check while keeping the
+  runtime error message users see — `assert_never()` would replace it with an
+  `AssertionError`. Never do this inside an `@njit` kernel (see `vect.py`'s
+  `_trend`): Numba cannot compile it.
+- `@override` goes on overrides of **concrete** base methods only. Abstract
+  methods are already enforced by ABC. It matters most in `slippage.py`, where
+  `apply_slippage` has a no-op default and `is_fill_noop` detects overriding by
+  method identity — so a typo there silently disables slippage.
 - Typing: pre-PEP-604 `Optional[X]`/`Union[X, Y]` is the convention (one
   existing exception: `scope.py` has a bare `X | None`), but modern
   builtin generics (`dict[str, int]`, `tuple[str, ...]`); `NDArray[np.float64]`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 #########
 
+2.0.1
+=====
+
+* Adds ``typing_extensions`` to install dependencies. It was already imported by :mod:`pybroker.strategy` but never declared, so installs relied on it being pulled in indirectly by another dependency.
+
 2.0.0
 =====
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     numpy>=1.26.4,<3
     pandas>=2.2.0,<4
     progressbar2>=4.1.1,<5
+    typing_extensions>=4.10,<5
     yahooquery>=2.3.7,<3
     yfinance>=0.2.55,<2
 

--- a/src/pybroker/common.py
+++ b/src/pybroker/common.py
@@ -25,10 +25,9 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
-    TypeGuard,
     Union,
-    cast,
 )
+from typing_extensions import TypeIs
 
 if TYPE_CHECKING:
     from pybroker.strategy import Execution
@@ -651,7 +650,7 @@ def _dataframe_records(
 
 def _is_symbol_selector(
     symbols: Union[frozenset[str], SymbolSelector],
-) -> TypeGuard[SymbolSelector]:
+) -> TypeIs[SymbolSelector]:
     """Returns whether ``symbols`` is a :class:`.SymbolSelector`."""
     return callable(symbols) and not isinstance(symbols, (str, bytes))
 
@@ -664,7 +663,7 @@ def _static_symbols(
     window is split."""
     if _is_symbol_selector(symbols):
         return frozenset()
-    return cast(frozenset[str], symbols)
+    return symbols
 
 
 def _ensure_range_index(df: pd.DataFrame) -> pd.DataFrame:
@@ -723,7 +722,7 @@ def _resolve_execution_symbols(
                 f"symbol selector returned unknown symbols: {sorted(unknown)}."
             )
         return frozenset(selected)
-    return cast(frozenset[str], execution.symbols)
+    return execution.symbols
 
 
 def _resolve_executions(

--- a/src/pybroker/data.py
+++ b/src/pybroker/data.py
@@ -10,6 +10,7 @@ import sys
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Final, Iterable, Optional, Union
+from typing_extensions import override
 
 import alpaca.data.historical.crypto as alpaca_crypto
 import alpaca.data.historical.stock as alpaca_stock
@@ -383,6 +384,7 @@ class Alpaca(DataSource):
         super().__init__()
         self._api = alpaca_stock.StockHistoricalDataClient(api_key, api_secret)
 
+    @override
     def query(
         self,
         symbols: Union[str, Iterable[str]],
@@ -477,6 +479,7 @@ class AlpacaCrypto(DataSource):
             api_key, api_secret
         )
 
+    @override
     def query(
         self,
         symbols: Union[str, Iterable[str]],
@@ -540,6 +543,7 @@ class YFinance(DataSource):
         self.auto_adjust = auto_adjust
         self._scope.register_custom_cols(self.ADJ_CLOSE)
 
+    @override
     def query(
         self,
         symbols: Union[str, Iterable[str]],

--- a/src/pybroker/portfolio.py
+++ b/src/pybroker/portfolio.py
@@ -40,6 +40,7 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
+    Never,
     Optional,
     Union,
     cast,
@@ -646,6 +647,7 @@ class Portfolio:
         elif self._fee_mode == FeeMode.PER_SHARE:
             fees = self._fee_amount * shares
         else:
+            _unreachable_fee_mode: Never = self._fee_mode
             raise ValueError(f"Unknown FeeMode: {self._fee_mode!r}")
         return fees
 
@@ -1967,6 +1969,7 @@ class Portfolio:
         elif stop.stop_type == StopType.TRAILING:
             fill_price = self._trigger_trailing_stop(stop, price_scope)
         else:
+            _unreachable_trigger_stop_type: Never = stop.stop_type
             raise ValueError(f"Unknown stop type: {stop.stop_type}")
         if fill_price is None:
             return False, fill_price
@@ -2001,6 +2004,7 @@ class Portfolio:
             )
             order_type = "buy"
         else:
+            _unreachable_pos_type: Never = stop.pos_type
             raise ValueError(f"Unknown pos_type: {stop.pos_type}")
         if stop.pos_type == "long":
             intent = PositionIntent.SELL_TO_CLOSE
@@ -2015,6 +2019,7 @@ class Portfolio:
         elif stop.stop_type == StopType.TRAILING:
             stop_order_type = OrderType.STOP_TRAILING
         else:
+            _unreachable_order_stop_type: Never = stop.stop_type
             raise ValueError(f"Unknown stop type: {stop.stop_type}")
         self._add_order(
             date=date,

--- a/src/pybroker/scope.py
+++ b/src/pybroker/scope.py
@@ -49,6 +49,7 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
+    Never,
     Optional,
     Sequence,
     Union,
@@ -2331,6 +2332,7 @@ class PriceScope:
             close = self._fetch_price_type(symbol, _PRICE_CLOSE)
             fill_price = (open_ + low + high + close) / 4.0
         else:
+            _unreachable_price: Never = price
             raise ValueError(f"Unknown price: {price!r}")
         self._bar_cache[key] = fill_price
         return fill_price

--- a/src/pybroker/slippage.py
+++ b/src/pybroker/slippage.py
@@ -13,6 +13,7 @@ from abc import ABC
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import TYPE_CHECKING, Literal, Mapping, Optional
+from typing_extensions import override
 
 from pybroker.common import DataCol, to_decimal
 from pybroker.scope import ColumnScope, IndicatorScope
@@ -209,6 +210,7 @@ class FixedSlippageModel(SlippageModel):
             return fill_price * self._buy_multiplier
         return fill_price * self._sell_multiplier
 
+    @override
     def apply_slippage(self, ctx: SlippageContext) -> tuple[Decimal, Decimal]:
         return (
             ctx.shares,
@@ -245,6 +247,7 @@ class VolatilitySlippageModel(SlippageModel):
     def is_fill_noop(self) -> bool:
         return self.scale == 0
 
+    @override
     def apply_slippage(self, ctx: SlippageContext) -> tuple[Decimal, Decimal]:
         if self.scale == 0:
             return ctx.shares, ctx.fill_price
@@ -349,6 +352,7 @@ class VolumeSlippageModel(SlippageModel):
     def is_fill_noop(self) -> bool:
         return not self._cap_enabled and not self._impact_enabled
 
+    @override
     def validate(self, strategy: "Strategy") -> None:
         if self.is_fill_noop:
             return
@@ -374,6 +378,7 @@ class VolumeSlippageModel(SlippageModel):
             stacklevel=2,
         )
 
+    @override
     def apply_slippage(self, ctx: SlippageContext) -> tuple[Decimal, Decimal]:
         if self.is_fill_noop:
             return ctx.shares, ctx.fill_price

--- a/src/pybroker/strategy.py
+++ b/src/pybroker/strategy.py
@@ -113,6 +113,7 @@ from numpy.typing import NDArray
 from typing import (
     Any,
     Callable,
+    Concatenate,
     Iterable,
     Iterator,
     Literal,
@@ -120,11 +121,11 @@ from typing import (
     MutableMapping,
     NamedTuple,
     Optional,
+    ParamSpec,
     Sequence,
     TypeGuard,
     Union,
 )
-from typing_extensions import Concatenate, ParamSpec
 
 
 P = ParamSpec("P")


### PR DESCRIPTION
`src/pybroker/strategy.py` imported `Concatenate` and `ParamSpec` from
`typing_extensions`, but **the package is declared nowhere** — not in
`install_requires`, not in `requirements.txt`. It resolves today only because
transitive dependencies (alembic via optuna, beautifulsoup4, anyio) happen to
pull it in, and nothing in CI cross-checks imports against declared
dependencies. If any of them drops it, `import pybroker` breaks for users.

Both names have been stdlib since **3.10**, below the 3.11 floor, so they move
to `from typing import ...` and the anomaly disappears. That raised the better
question — if we declare `typing_extensions` properly, what does it actually buy
here? An audit of the typing surface across 19 modules found three things worth
adopting and several worth explicitly rejecting.

## 1. `@override` — guards a silent feature-disablement bug

`SlippageModel.apply_slippage` is **not abstract**. It is a concrete no-op
default, and `is_fill_noop` detects overriding by method identity:

```python
return type(self).apply_slippage is SlippageModel.apply_slippage
```

So a misspelled override does not merely inherit the base — `is_fill_noop`
returns `True` and **the engine skips slippage entirely** for that model. Nothing
caught this before.

Applied to the **7 concrete overrides** (mapped by AST, not by eye):
`Alpaca.query`, `AlpacaCrypto.query`, `YFinance.query`,
`FixedSlippageModel.apply_slippage`, `VolatilitySlippageModel.apply_slippage`,
`VolumeSlippageModel.apply_slippage`, `VolumeSlippageModel.validate`.

Not applied to `_fetch_data` — it is abstract, so ABC already enforces it and
`@override` would add nothing.

**Proven, not assumed**: renaming `apply_slippage` → `apply_slipage` in one
subclass now fails typecheck with
`override, but no base method was found with this name [misc]`.

## 2. Exhaustiveness on five `if/elif` chains

`FeeMode`, `StopType` (**two** chains, both inside `_trigger_stop`), `pos_type`,
and `PriceType`.

These use the `Never`-assignment idiom rather than `assert_never()`:

```python
else:
    _unreachable_fee_mode: Never = self._fee_mode
    raise ValueError(f"Unknown FeeMode: {self._fee_mode!r}")
```

`assert_never()` would replace a `ValueError` carrying a useful message with an
`AssertionError` — a real regression for a library whose users can pass an
arbitrary value at runtime, where the enum is not enforced. This gets the static
check and leaves the runtime behaviour byte-identical. `Never` is stdlib from
3.11, so it needs no dependency.

**Proven**: removing the `FeeMode.PER_SHARE` branch now fails typecheck with
`Incompatible types in assignment (... variable has type "Never")`.

A probe first confirmed `_` cannot be reused within one function
(`Name "_" already defined`), which is why the three guards in `_trigger_stop`
carry distinct semantic names.

**`vect.py`'s `_trend` is deliberately untouched** — exhaustive over
`Literal["linear","quadratic","cubic"]`, but inside an `@njit(cache=True)`
kernel, which Numba cannot compile this into.

## 3. `TypeIs` on `_is_symbol_selector` — removes two casts

`TypeGuard` narrows only the positive branch, which is why **both**
`_static_symbols` and `_resolve_execution_symbols` needed
`cast(frozenset[str], ...)` on their fall-through. `TypeIs` narrows both, so both
casts are gone, along with the now-unused `cast` and `TypeGuard` imports.

**`_is_rankable` deliberately stays `TypeGuard`.** It returns `False` for NaN,
which *is* a `float` — a value predicate, not a type predicate. `TypeIs` would
wrongly narrow its negative branch to `None` and break the
`result.score is not None` logic. A case where the older construct is correct.

## Why the dependency is unconditional

| feature | stdlib since | needs `typing_extensions` on |
|---|---|---|
| `Concatenate`, `ParamSpec`, `Never` | ≤3.11 | nothing |
| `override` | 3.12 | 3.11 |
| `TypeIs` | 3.13 | 3.11 **and** 3.12 |

A `; python_version < "3.12"` marker would be wrong, since `TypeIs` is needed on
3.12 too, and would need re-scoping at every floor bump. Floor is `4.10` because
`TypeIs` (PEP 742) landed there (`override` is 4.4).

No runtime cost: `typing_extensions` re-exports the stdlib object where one
exists — `typing.override is typing_extensions.override` → `True` on 3.12 — so
this is not a backport shim. Not added to `requirements.txt`, which feeds only
`[testenv:docs]` and `.readthedocs.yml`.

## Rejected after investigation

- **`@deprecated`** — the deprecated `StrategyConfig` fields are *dataclass
  fields*, which it cannot decorate, and all three deprecated things (both
  fields plus `ExecContext.score`) are *conditionally* deprecated, only when set
  to non-`None`. `@deprecated` warns on every use of a symbol and cannot express
  that. The existing `warnings.warn` guards are the more precise tool and stay.
- **`Unpack[TypedDict]`** — no candidates; every loose `**kwargs` forwards to
  something inherently open-ended.
- **`Self`** — candidates exist but none of those classes is subclassed, so the
  win would be documentation only.
- **`TypeVar`/`Generic`** — zero sites; nothing generic-shaped to model.

## Checks

`ruff format --diff` clean · `ruff check` clean · `mypy
--warn-unused-ignores` clean · **full suite 5224 passed** · strict docs build
(`-n -W`) exit 0 with **zero** warnings · sdist metadata carries
`Requires-Dist: typing_extensions<5,>=4.10`.

## One thing to check

I added a **`2.0.1` changelog section** — `v2.0.0` is the last tag, `__version__`
is already `2.0.1`, and no section existed for it. The repo's habit looks like
batching changelog entries per release rather than per PR, so move it if that is
wrong. Adding a runtime dependency changes what `pip install` pulls, which the
akshare-removal bullet under 2.0.0 suggests is worth recording.

Also independent of, and not blocked by, the Python 3.11 drop.
