### PR TITLE
fix: reject malformed timeframe tokens

### DIFF
--- a/src/pybroker/common.py
+++ b/src/pybroker/common.py
@@ -387,9 +387,14 @@ def parse_timeframe(timeframe: str) -> list[tuple[int, str]]:
         value and ``str`` unit of one of the following: ``sec``, ``min``,
         ``hour``, ``day``, ``week``.
     """
-    parts = _tf_pattern.findall(timeframe)
     tokens = timeframe.split()
-    if not parts or len(parts) != len(tokens):
+    parts = []
+    for token in tokens:
+        match = _tf_pattern.fullmatch(token)
+        if match is None:
+            raise ValueError("Invalid timeframe format.")
+        parts.append(match.groups())
+    if not parts:
         raise ValueError("Invalid timeframe format.")
     result = []
     seen_units = set()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -139,6 +139,7 @@ def test_bars_to_df_when_optional_cols_none():
         ("10week", [(10, "week")]),
         ("3d 20m", [(3, "day"), (20, "min")]),
         ("30s", [(30, "sec")]),
+        ("  1H   30MIN  ", [(1, "hour"), (30, "min")]),
     ],
 )
 def test_parse_timeframe_success(tf, expected):
@@ -157,6 +158,12 @@ def test_parse_timeframe_success(tf, expected):
         "1d5m",
         "1d 5mm",
         "",
+        "1.5h",
+        "-1h",
+        "+1h",
+        "1h,",
+        "1h!",
+        "1h 30m?",
     ],
 )
 def test_parse_timeframe_invalid(tf):


### PR DESCRIPTION
## Fix

`parse_timeframe()` currently accepts malformed tokens because `findall()` can skip unmatched characters: `1.5h` becomes five hours, and `-1h` becomes one hour. Require each whitespace-separated token to match completely, while preserving valid aliases, capitalization, and whitespace handling.

## Validation

- Added six malformed-token regression cases and a mixed-case/whitespace control; all 80 `test_common.py` tests pass.
- `tox -e format,lint,typecheck` passes.
- Full-suite diagnostic with external requests explicitly blocked: 5210 passed, 18 YahooQuery failures, 3 Ray setup errors from the local UNIX socket path length. The three Ray tests passed in a separate rerun with a shorter temporary path. The YahooQuery constructor also attempts network access on the unchanged base; an unmodified test times out connecting to `finance.yahoo.com`. The unmodified full-suite attempt was interrupted by these environment problems; no full-suite pass is claimed.

No dependency, data-source, or test-configuration changes are included.
